### PR TITLE
feature/zms-38 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/src/bin/zmcertmgr
+++ b/src/bin/zmcertmgr
@@ -60,8 +60,8 @@ Where valid command/option combinations are:
   verifycrtchain <ca_chain_file> <certfile>
   verifycrtkey   <priv_key>      <certfile>
 
-  viewdeployedcrt    [all|ldap|mailboxd|mta|proxy]
-  checkcrtexpiration [all|ldap|mailboxd|mta|proxy] [-days days]
+  viewdeployedcrt    [all|ldap|mailboxd|mta|proxy|imapd]
+  checkcrtexpiration [all|ldap|mailboxd|mta|proxy|imapd] [-days days]
   addcacert <certfile>
   migrate
 
@@ -126,7 +126,7 @@ The set of services to be used for a request. The service names can be
 specified as comma separate values or the B<-deploy> argument can be
 used multiple times.
 
-Valid services are 'all' or any of: ldap,mailboxd,mta,proxy.
+Valid services are 'all' or any of: ldap,mailboxd,mta,proxy,imapd.
 
 =item B<-subject> I<subject>
 
@@ -558,6 +558,16 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
             $self->Keytool, @args,
             "-keystore",    $self->sslFiles("keystore"),
             "-storepass",   $self->lc->get("mailboxd_keystore_password"),
+            "2>&1",
+        );
+    }
+
+    sub runImapdKeytool {
+        my ( $self, @args ) = @_;
+        return $self->run(
+            $self->Keytool, @args,
+            "-keystore",    $self->sslFiles("imapd_keystore"),
+            "-storepass",   $self->lc->get("imapd_keystore_password"),
             "2>&1",
         );
     }
@@ -1135,6 +1145,10 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
                       or return undef;
                     $self->_copy( $keyf, $dkey )
                       or return undef;
+                    if ( $name eq "imapd" ) {
+                        $self->createimapdkeystore($type)
+                          or return undef;
+                    }
                 }
             }
             print("** NOTE: restart services to use the new certificates.\n");
@@ -1600,7 +1614,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
     sub viewdeployedcrt {
         my ( $self, $sname ) = ( shift, @_ );
 
-        my $usage = "viewdeployedcrt [all|ldap|mailboxd|mta|proxy]";
+        my $usage = "viewdeployedcrt [all|ldap|mailboxd|mta|proxy|imapd]";
         warn("DEBUG: viewdeployedcrt(@_)\n") if $self->Debug;
 
         if ($sname) {
@@ -1646,7 +1660,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
 
         # ldap => ldap_crt, ...
         my %svc;
-        foreach my $s (qw(ldap mailboxd mta proxy)) {
+        foreach my $s (qw(ldap mailboxd mta proxy imapd)) {
             $svc{$s} = $nofiles ? 1 : $self->sslFiles( $s . "_crt" );
         }
         return ( $sname eq "all" ) ? %svc : ( $sname => $svc{$sname} );
@@ -1694,7 +1708,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
     sub checkcrtexpiration {
         my ( $self, $sname ) = ( shift, @_ );
 
-        my $usage = "checkcrtexpiration [all|ldap|mailboxd|mta|proxy]";
+        my $usage = "checkcrtexpiration [all|ldap|mailboxd|mta|proxy|imapd]";
         warn("DEBUG: checkcrtexpiration(@_)\n") if $self->Debug;
 
         if ($sname) {
@@ -1799,6 +1813,67 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         # - store both private key and certificate in the keystore
         my $pkcsf = $self->sslFiles("pkcs");
         my $kpass = $self->lc->get("mailboxd_keystore_password");
+        print("** Creating file '$pkcsf'\n");
+        @out = $self->run(
+            $self->Openssl, "pkcs12", "-inkey", $keyf,
+            "-in",          $crtf,    "-name",  $server,
+            "-export",      "-out",   $pkcsf,   "-passout",
+            "pass:$kpass",  "2>&1"
+        );
+        if ( $? != 0 or !-s $pkcsf ) {
+            $self->error( "openssl pkcs12 export to '$pkcsf' failed(",
+                $? >> 8, "):\n", @out );
+            return undef;
+        }
+
+        print("** Creating keystore '$keystore'\n");
+        my $cpath =
+"/opt/zimbra/lib/ext/com_zimbra_cert_manager/com_zimbra_cert_manager.jar";
+        my $class = "com.zimbra.cert.MyPKCS12Import";
+
+        @out = $self->run(
+            $self->Java, "-classpath", $cpath, $class,
+            $pkcsf,      $keystore,    $kpass, $kpass,
+            "2>&1",
+        );
+        if ( $? != 0 or !-s $keystore ) {
+            $self->error( "$class to '$pkcsf' returned non-zero(",
+                $? >> 8, "):\n", @out );
+            return undef;
+        }
+
+        return 1;
+    }
+
+    # createimapdkeystore <self|comm>
+    sub createimapdkeystore {
+        my ( $self, $type ) = ( shift, @_ );
+        warn("DEBUG: createimapdkeystore(@_)\n") if $self->Debug;
+        $self->_checkType($type) or return undef;
+
+        my $keyf = $self->sslFiles( "imapd_key" );
+        my $crtf = $self->sslFiles( "imapd_crt" );
+        $self->_checkFiles( $keyf, $crtf ) or return undef;
+
+        # clean up any previous settings first
+        my $keystore = $self->sslFiles("imapd_keystore");
+        my $server   = $self->lc->get("mailboxd_server");
+        $server ||= $self->lc->get("zimbra_server_hostname");
+
+        my @out;
+        my @cmd = ( "-delete", "-alias", $server );
+        if ( -f $keystore ) {
+            @out = $self->runImapdKeytool(@cmd);
+            if ( $? != 0 and !grep { /does not exist/ } @out ) {
+                $self->error( "imapd keytool(@cmd) returned non-zero(",
+                    $? >> 8, "):\n", @out );
+            }
+        }
+
+        # loading keys and certificates via PKCS12
+        # - store both private key and certificate in the keystore
+        my $pkcsf = $self->sslFiles("pkcs");
+        my $kpass = $self->lc->get("imapd_keystore_password");
         print("** Creating file '$pkcsf'\n");
         @out = $self->run(
             $self->Openssl, "pkcs12", "-inkey", $keyf,
@@ -2139,6 +2214,8 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
                 # OLD: in_ssl_conf and zimbra_cert_ssl_conf
                 ssl_conf_in   => $confdir . "/zmssl.cnf.in",
                 ssl_conf_cert => $confdir . "/zmssl.cnf",
+                imapd_crt      => $confdir . "/imapd.crt",
+                imapd_key      => $confdir . "/imapd.key",
                 ldap_crt      => $confdir . "/slapd.crt",
                 ldap_key      => $confdir . "/slapd.key",
                 mta_crt       => $confdir . "/smtpd.crt",
@@ -2148,6 +2225,8 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
 
                 cacerts  => $self->lc->get("mailboxd_truststore"),
                 keystore => $self->lc->get("mailboxd_keystore"),
+                imapd_keystore => $self->lc->get("imapd_keystore"),
+                imapd_keystore_password => $self->lc->get("imapd_keystore_password"),
 
                 # deployed CA
                 conf_ca_crt => "$confcad/ca.pem",
@@ -2381,7 +2460,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         # xargs     - arrayref w/list of number of extra args allowed
         # xinfo     - useful error info about the extra args allowed
         my @create_opts = qw(new keysize=i digest=s subject=s);
-        my $services    = "[all|ldap|mailboxd|mta|proxy]";
+        my $services    = "[all|ldap|mailboxd|mta|proxy|imapd]";
 
         my %commands = (
 

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -71,6 +71,7 @@ my %startorder = (
 	"zimbra"	=> 180,
 	"zimbraAdmin"	=> 190,
 	"zimlet"	=> 200,
+	"imapd"		=> 210,
 	"vmware-ha"	=> 250,  # this should remain last
 );
 
@@ -96,7 +97,8 @@ my %stoporder = (
 	"zimbra"	=> 170,
 	"zimbraAdmin"	=> 180,
 	"zimlet"	=> 190,
-	"zmconfigd"	=> 200,
+	"imapd"		=> 200,
+	"zmconfigd"	=> 210,
 	"vmware-ha"	=> 250,
 );
 
@@ -124,6 +126,7 @@ my %allservices = (
 	"zmconfigd" => "/opt/zimbra/bin/zmconfigdctl",
 	"cbpolicyd" => "/opt/zimbra/bin/zmcbpolicydctl",
 	"vmware-ha" => "/opt/zimbra/bin/zmhactl",
+	"imapd" => "/opt/zimbra/bin/zmimapdctl",
 );
 
 my %rewrites = ( 

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -57,7 +57,7 @@ function is_running {
 #
 
 case "$1" in
-  'start')
+  start)
     if [ "$(is_running)" = "no" ]; then
       /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
       ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
@@ -77,7 +77,7 @@ case "$1" in
       exit 0
     fi
     ;;
-  'kill'|'stop')
+  kill|stop)
     if [ "$(is_running)" = "yes" ]; then
       echo "stopping IMAP daemon..."
       $KILL -TERM "$($CAT $PID_FILE)"
@@ -85,11 +85,11 @@ case "$1" in
     fi
     exit 0
     ;;
-  'restart'|'reload')
+  restart|reload)
     $0 stop
     $0 start
     ;;
-  'status')
+  status)
     echo -n "imap is "
     if [ "$(is_running)" = "yes" ]; then
       echo "running."

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -26,9 +26,18 @@ if [ ! -d "${zimbra_java_home}" ]; then
   exit 1
 fi
 
-#
-# TODO-JVM options
-# 
+# shellcheck disable=SC2154
+JVM_OPTS="${imapd_java_options}"
+JVM_HS=""
+# shellcheck disable=SC2154
+if [ -n "${imapd_java_heap_size}" ]; then
+  JVM_HS="-Xms${imapd_java_heap_size}m -Xmx${imapd_java_heap_size}m"
+fi
+JVM_HNS=""
+# shellcheck disable=SC2154
+if [ -n "${imapd_java_heap_new_size_percent}" ]; then
+  JVM_HNS="-Xmn${imapd_java_heap_new_size_percent}m"
+fi
 
 PID_FILE=/opt/zimbra/log/imapd.pid
 NOHUP_FILE=/opt/zimbra/log/imapd.out
@@ -76,14 +85,15 @@ case "$1" in
   start)
     if [ "$(is_running)" = "no" ]; then
       /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
-      ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
+      # shellcheck disable=SC2086
+      ${NOHUP} "${JAVA}" ${JVM_OPTS} ${JVM_HS} ${JVM_HNS} -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
       PID=$!
       echo -n $PID > $PID_FILE
       if [ "$(is_running)" = "yes" ]; then
         echo "IMAP service started with PID=${PID}"
         exit 0
       else
-        cat $NOHUP_FILE
+        $CAT $NOHUP_FILE
         exit 1
       fi
     else

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -45,8 +45,7 @@ RM=/bin/rm
 #
 
 function is_running {
-    if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null
-    then
+    if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null; then
         echo yes
     else
         echo no
@@ -59,16 +58,14 @@ function is_running {
 
 case "$1" in
     'start')
-        if [ "$(is_running)" = "no" ]
-        then
+        if [ "$(is_running)" = "no" ]; then
             /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
             ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
             PID=$!
             echo -n $PID > $PID_FILE
             # TODO - find deterministic way to tell when Java has completed startup
             sleep 2
-            if [ "$(is_running)" = "yes" ]
-            then
+            if [ "$(is_running)" = "yes" ]; then
                 echo "IMAP service started with PID=${PID}"
                 exit 0
             else
@@ -81,8 +78,7 @@ case "$1" in
         fi
         ;;
     'kill'|'stop')
-        if [ "$(is_running)" = "yes" ]
-        then
+        if [ "$(is_running)" = "yes" ]; then
             echo "stopping IMAP daemon..."
             $KILL -TERM "$($CAT $PID_FILE)"
             $RM $PID_FILE
@@ -95,8 +91,7 @@ case "$1" in
         ;;
     'status')
         echo -n "imap is "
-        if [ "$(is_running)" = "yes" ]
-        then
+        if [ "$(is_running)" = "yes" ]; then
             echo "running."
             exit 0
         else

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -16,16 +16,14 @@
 # ***** END LICENSE BLOCK *****
 # 
 
-source `dirname $0`/zmshutil || exit 1
+SDIR=$(dirname "$0")
+source "${SDIR}/zmshutil" || exit 1
 zmsetvars
 
-if [ ! -d ${zimbra_java_home} ]; then
+if [ ! -d "${zimbra_java_home}" ]; then
     (>&2 echo "Did not find java at '${jar_prefix}'")
     exit 1
 fi
-
-NC=`which nc 2>/dev/null`; NC=${NC:-`which netcat 2>/dev/null`}
-platform=`/opt/zimbra/libexec/get_plat_tag.sh`
 
 #
 # TODO-JVM options
@@ -36,7 +34,6 @@ NOHUP_FILE=/opt/zimbra/log/imapd.out
 
 CAT=/bin/cat
 JAVA="${zimbra_java_home}/bin/java"
-JAVAD="${zimbra_java_home}/bin/java -agentlib:jdwp=transport=dt_socket,server=y,address=9000,suspend=n"
 LS=/bin/ls
 KILL=/bin/kill
 NOHUP=/usr/bin/nohup
@@ -61,7 +58,7 @@ function find_jar {
 }
 
 function is_running {
-    if [ -f $PID_FILE ] && $($PS augx | grep -q $($CAT $PID_FILE))
+    if [ -f $PID_FILE ] && $PS augx | grep -q "$($CAT $PID_FILE)"
     then
         echo yes
     else
@@ -75,15 +72,15 @@ function is_running {
 
 case "$1" in
     'start')
-        if [ $(is_running) = "no" ]
+        if [ "$(is_running)" = "no" ]
         then
             /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
-            ${NOHUP} ${JAVAD} -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
+            ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
             PID=$!
             echo -n $PID > $PID_FILE
             # TODO - find deterministic way to tell when Java has completed startup
             sleep 2
-            if [ $(is_running) = "yes" ]
+            if [ "$(is_running)" = "yes" ]
             then
                 echo "IMAP service started with PID=${PID}"
                 exit 0
@@ -97,10 +94,10 @@ case "$1" in
         fi
         ;;
     'kill'|'stop')
-        if [ $(is_running) = "yes" ]
+        if [ "$(is_running)" = "yes" ]
         then
             echo "stopping IMAP daemon..."
-            $KILL -TERM $($CAT $PID_FILE)
+            $KILL -TERM "$($CAT $PID_FILE)"
             $RM $PID_FILE
         fi
         exit 0
@@ -111,7 +108,7 @@ case "$1" in
         ;;
     'status')
         echo -n "imap is "
-        if [ $(is_running) = "yes" ]
+        if [ "$(is_running)" = "yes" ]
         then
             echo "running."
             exit 0

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -44,19 +44,6 @@ RM=/bin/rm
 # Utility
 #
 
-function find_jar {
-    jar_prefix="$1"
-    jar_path=$($LS "${jar_prefix}"*".jar" 2>/dev/null)
-    
-    if [ "${jar_path}" = "" ]
-    then
-        (>&2 echo "Error resolving jar_prefix '${jar_prefix}'") 
-        exit 1
-    else
-        echo -n "$jar_path"
-    fi
-}
-
 function is_running {
     if [ -f $PID_FILE ] && $PS augx | grep -q "$($CAT $PID_FILE)"
     then

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -21,7 +21,7 @@ source "${SDIR}/zmshutil" || exit 1
 zmsetvars
 
 if [ ! -d "${zimbra_java_home}" ]; then
-    (>&2 echo "Did not find java at '${jar_prefix}'")
+    echo "Did not find java at '${zimbra_java_home}'" >&2
     exit 1
 fi
 

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -45,7 +45,7 @@ RM=/bin/rm
 #
 
 function is_running {
-    if [ -f $PID_FILE ] && $PS augx | grep -q "$($CAT $PID_FILE)"
+    if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null
     then
         echo yes
     else

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -20,6 +20,7 @@ SDIR=$(dirname "$0")
 source "${SDIR}/zmshutil" || exit 1
 zmsetvars
 
+# shellcheck disable=SC2154
 if [ ! -d "${zimbra_java_home}" ]; then
   echo "Did not find java at '${zimbra_java_home}'" >&2
   exit 1
@@ -31,25 +32,40 @@ fi
 
 PID_FILE=/opt/zimbra/log/imapd.pid
 NOHUP_FILE=/opt/zimbra/log/imapd.out
+RUNNING_CHECK_SLEEP=1
+RUNNING_CHECK_TRIES=10
 
 CAT=/bin/cat
+EXPR=/usr/bin/expr
 JAVA="${zimbra_java_home}/bin/java"
-LS=/bin/ls
 KILL=/bin/kill
 NOHUP=/usr/bin/nohup
 PS=/bin/ps
 RM=/bin/rm
+SLEEP=/bin/sleep
 
 #
 # Utility
 #
 
 function is_running {
-  if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null; then
-    echo yes
-  else
-    echo no
-  fi
+  attempt=1
+  rc=no
+  while [ $attempt -le $RUNNING_CHECK_TRIES ]; do
+    attempt=$($EXPR $attempt + 1)
+    if [ -f $PID_FILE ]; then
+      pid="$($CAT $PID_FILE)"
+      if $PS -p "${pid}" >/dev/null; then
+        rc=yes
+        break
+      else
+        $SLEEP $RUNNING_CHECK_SLEEP
+      fi
+    else
+      break
+    fi
+  done
+  echo $rc
 }
 
 #
@@ -63,8 +79,6 @@ case "$1" in
       ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
       PID=$!
       echo -n $PID > $PID_FILE
-      # TODO - find deterministic way to tell when Java has completed startup
-      sleep 2
       if [ "$(is_running)" = "yes" ]; then
         echo "IMAP service started with PID=${PID}"
         exit 0

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -1,0 +1,128 @@
+#!/bin/bash
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2017 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+source `dirname $0`/zmshutil || exit 1
+zmsetvars
+
+if [ ! -d ${zimbra_java_home} ]; then
+    (>&2 echo "Did not find java at '${jar_prefix}'")
+    exit 1
+fi
+
+NC=`which nc 2>/dev/null`; NC=${NC:-`which netcat 2>/dev/null`}
+platform=`/opt/zimbra/libexec/get_plat_tag.sh`
+
+#
+# TODO-JVM options
+# 
+
+PID_FILE=/opt/zimbra/log/imapd.pid
+NOHUP_FILE=/opt/zimbra/log/imapd.out
+
+CAT=/bin/cat
+JAVA="${zimbra_java_home}/bin/java"
+JAVAD="${zimbra_java_home}/bin/java -agentlib:jdwp=transport=dt_socket,server=y,address=9000,suspend=n"
+LS=/bin/ls
+KILL=/bin/kill
+NOHUP=/usr/bin/nohup
+PS=/bin/ps
+RM=/bin/rm
+
+#
+# Utility
+#
+
+function find_jar {
+    jar_prefix="$1"
+    jar_path=$($LS "${jar_prefix}"*".jar" 2>/dev/null)
+    
+    if [ "${jar_path}" = "" ]
+    then
+        (>&2 echo "Error resolving jar_prefix '${jar_prefix}'") 
+        exit 1
+    else
+        echo -n "$jar_path"
+    fi
+}
+
+function is_running {
+    if [ -f $PID_FILE ] && $($PS augx | grep -q $($CAT $PID_FILE))
+    then
+        echo yes
+    else
+        echo no
+    fi
+}
+
+#
+# Main
+#
+
+case "$1" in
+    'start')
+        if [ $(is_running) = "no" ]
+        then
+            /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
+            ${NOHUP} ${JAVAD} -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
+            PID=$!
+            echo -n $PID > $PID_FILE
+            # TODO - find deterministic way to tell when Java has completed startup
+            sleep 2
+            if [ $(is_running) = "yes" ]
+            then
+                echo "IMAP service started with PID=${PID}"
+                exit 0
+            else
+                cat $NOHUP_FILE
+                exit 1
+            fi
+        else
+            echo "IMAP service running with PID=$($CAT $PID_FILE)"
+            exit 0
+        fi
+        ;;
+    'kill'|'stop')
+        if [ $(is_running) = "yes" ]
+        then
+            echo "stopping IMAP daemon..."
+            $KILL -TERM $($CAT $PID_FILE)
+            $RM $PID_FILE
+        fi
+        exit 0
+        ;;
+    'restart'|'reload')
+        $0 stop
+        $0 start
+        ;;
+    'status')
+        echo -n "imap is "
+        if [ $(is_running) = "yes" ]
+        then
+            echo "running."
+            exit 0
+        else
+            echo "not running."
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 start|stop|kill|restart|reload|status"
+        exit 1
+        ;;
+esac
+

--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -21,8 +21,8 @@ source "${SDIR}/zmshutil" || exit 1
 zmsetvars
 
 if [ ! -d "${zimbra_java_home}" ]; then
-    echo "Did not find java at '${zimbra_java_home}'" >&2
-    exit 1
+  echo "Did not find java at '${zimbra_java_home}'" >&2
+  exit 1
 fi
 
 #
@@ -45,11 +45,11 @@ RM=/bin/rm
 #
 
 function is_running {
-    if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null; then
-        echo yes
-    else
-        echo no
-    fi
+  if [ -f $PID_FILE ] && $PS -p "$($CAT $PID_FILE)" >/dev/null; then
+    echo yes
+  else
+    echo no
+  fi
 }
 
 #
@@ -57,51 +57,51 @@ function is_running {
 #
 
 case "$1" in
-    'start')
-        if [ "$(is_running)" = "no" ]; then
-            /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
-            ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
-            PID=$!
-            echo -n $PID > $PID_FILE
-            # TODO - find deterministic way to tell when Java has completed startup
-            sleep 2
-            if [ "$(is_running)" = "yes" ]; then
-                echo "IMAP service started with PID=${PID}"
-                exit 0
-            else
-                cat $NOHUP_FILE
-                exit 1
-            fi
-        else
-            echo "IMAP service running with PID=$($CAT $PID_FILE)"
-            exit 0
-        fi
-        ;;
-    'kill'|'stop')
-        if [ "$(is_running)" = "yes" ]; then
-            echo "stopping IMAP daemon..."
-            $KILL -TERM "$($CAT $PID_FILE)"
-            $RM $PID_FILE
-        fi
+  'start')
+    if [ "$(is_running)" = "no" ]; then
+      /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
+      ${NOHUP} "${JAVA}" -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
+      PID=$!
+      echo -n $PID > $PID_FILE
+      # TODO - find deterministic way to tell when Java has completed startup
+      sleep 2
+      if [ "$(is_running)" = "yes" ]; then
+        echo "IMAP service started with PID=${PID}"
         exit 0
-        ;;
-    'restart'|'reload')
-        $0 stop
-        $0 start
-        ;;
-    'status')
-        echo -n "imap is "
-        if [ "$(is_running)" = "yes" ]; then
-            echo "running."
-            exit 0
-        else
-            echo "not running."
-            exit 1
-        fi
-        ;;
-    *)
-        echo "Usage: $0 start|stop|kill|restart|reload|status"
+      else
+        cat $NOHUP_FILE
         exit 1
-        ;;
+      fi
+    else
+      echo "IMAP service running with PID=$($CAT $PID_FILE)"
+      exit 0
+    fi
+    ;;
+  'kill'|'stop')
+    if [ "$(is_running)" = "yes" ]; then
+      echo "stopping IMAP daemon..."
+      $KILL -TERM "$($CAT $PID_FILE)"
+      $RM $PID_FILE
+    fi
+    exit 0
+    ;;
+  'restart'|'reload')
+    $0 stop
+    $0 start
+    ;;
+  'status')
+    echo -n "imap is "
+    if [ "$(is_running)" = "yes" ]; then
+      echo "running."
+      exit 0
+    else
+      echo "not running."
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Usage: $0 start|stop|kill|restart|reload|status"
+    exit 1
+    ;;
 esac
 


### PR DESCRIPTION
## zm-core-utils

### zmimapdctl

This is the new bash script that is used to start and stop the _zimbra-imap_ service.

#### TODO - JVM configuration

The script needs to be able to supply appropriate JVM configuration options.  I have sent out an email to the team to solicit some feedback.  My current idea is to add the following _localconfig_ options:

* `imap_java_options`
  * Include this but perhaps leave empty for now until we can do some testing.
* `imap_java_heap_size`
  * If installing on a node that is NOT running mailboxd, use same value as `mailboxd_java_heap_size`, else use some smaller value
  * TODO - determine appropriate value
  * TODO - should we adjust `mailboxd_java_heap_size` down if installing `zimbra-imap` on same node as `mailboxd`?
* `imap_java_heap_new_size_percent`
  * Same value as `mailboxd_java_heap_new_size_percent` (at least initially)

#### TODO - Improved JVM startup monitoring

Currently the script is sleeping for 2 seconds after starting the _ImapDaemon_, via `nohup`, backgrounded.  So that call returns immediately.  The sleep allows some time to see if _ImapDaemon_ stated so that the appropriate exit code may be provided.

Looking to see if there is a better way to do this than via a sleep.

### zmcertmgr

The new IMAP servers look for a keystore at `/opt/zimbra/conf/keystore`.  Updates were made so that `deploycrt` creates the keystore.

### zmcontrol

Added the new IMAP service so that it may be started and stopped via `zmcontrol`

Please also see related pull requests for:

* `zm-zcs-lib`
* `zm-nginx-lookup-store`
* `zm-mailbox`
* `zm-build`

