### PR TITLE
ZCS-1373:zmlocalconfig --reload broken

### DIFF
--- a/src/bin/zmlocalconfig
+++ b/src/bin/zmlocalconfig
@@ -51,6 +51,8 @@ ${PATHSEP}${ZMROOT}/lib/jars/commons-cli-1.2.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/commons-httpclient-3.1.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/commons-codec-1.7.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/guava-13.0.1.jar\
+${PATHSEP}${ZMROOT}/lib/jars/httpclient-4.5.2.jar\
+${PATHSEP}${ZMROOT}/lib/jars/httpcore-4.4.5.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/dom4j-1.5.2.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/log4j-1.2.16.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/json.jar


### PR DESCRIPTION
`SoapHttpTransport` now uses `org.apache.http`