### PR TITLE
ZCS-1450 zimbra-imapd shutdown check

### DIFF
--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -364,6 +364,7 @@ sub doShutdown {
 	my $rrc = 0;
 	foreach (sort {$stoporder{$b} <=> $stoporder{$a}} keys %allservices) {
 		Zimbra::Mon::Logger::Log ("info", "Stopping $_ via zmcontrol");
+		if ($_ eq "imapd" && !(-f "/opt/zimbra/bin/zmimapdctl") ) { next; }
 		if ($_ eq "ldap" && !(-x "/opt/zimbra/common/libexec/slapd") ) { next; }
 		if ($_ eq "mta" && !(-x "/opt/zimbra/common/sbin/postfix") ) { next; }
 		if ($_ eq "snmp" && !(-f "/opt/zimbra/bin/zmswatchctl") ) { next; }


### PR DESCRIPTION
Added a check to `zmcontrol` when attempting to stop services so
that it will not attempt to stop `zimbra-imapd` service if the
control file is not present.