### PR TITLE
ZCS-1494 zmimapdctl and imap_always_use_remote_store

### DIFF
--- a/src/bin/zmimapdctl
+++ b/src/bin/zmimapdctl
@@ -84,7 +84,6 @@ function is_running {
 case "$1" in
   start)
     if [ "$(is_running)" = "no" ]; then
-      /opt/zimbra/bin/zmlocalconfig -e imap_always_use_remote_store=true
       # shellcheck disable=SC2086
       ${NOHUP} "${JAVA}" ${JVM_OPTS} ${JVM_HS} ${JVM_HNS} -cp /opt/zimbra/lib/jars/*: com.zimbra.cs.imap.ImapDaemon 1>$NOHUP_FILE 2>&1 &
       PID=$!


### PR DESCRIPTION
`zmimapdctl` will no longer alter the *localconfig* setting
`imap_always_use_remote_store`.  Altering the localconfig
setting will be obsoleted by related changes in `zm-mailbox`.