### PR TITLE
WIP: ZCS:2486 - Separated jetty.base and jetty.home, removed jetty-<version>

### DIFF
--- a/src/libexec/zmstat-proc
+++ b/src/libexec/zmstat-proc
@@ -178,7 +178,7 @@ sub filterProcs(;$$$) {
 }
 
 sub getMailboxProcess() {
-    my @regex = ('(mailboxd|jetty)/start\.jar');
+    my @regex = ('jetty_home/start[.]jar');
     my @ret = filterProcs($ZIMBRA_USER, \@regex);
     return @ret;
 }


### PR DESCRIPTION
- Zimbra's Jetty Distribution (9.3.5.v20151012) is installed in /opt/zimbra/common/jetty_home/ via a separate package.
- Zimbra specific webapps and other custom jetty configuration files will be installed in /opt/zimbra/jetty_base/.
- Now /opt/zimbra/mailboxd and /opt/zimbra/jetty are symbolic links that point to /opt/zimbra/jetty_base/.