### PR TITLE
Bug 96194: Make zmreplchk work with mismatched root passwords

### DIFF
--- a/src/libexec/zmreplchk
+++ b/src/libexec/zmreplchk
@@ -29,7 +29,7 @@ $c{zmlocalconfig}="/opt/zimbra/bin/zmlocalconfig";
 my $ldap_starttls_supported=getLocalConfig("ldap_starttls_supported");
 my $ldap_master=getLocalConfig("ldap_master_url");
 my $ldap_urls=getLocalConfig("ldap_url");
-my $ldap_pass=getLocalConfig("ldap_root_password");
+my $ldap_pass=getLocalConfig("ldap_master_root_password") || getLocalConfig("ldap_root_password");
 my ($mesgp, $entry);
 
 my @masters = split / /, $ldap_master;
@@ -71,7 +71,7 @@ foreach my $master (@masters) {
     next;
   }
   $mesgp=$ldapp->bind("cn=config", password => $ldap_pass);
-  $mesgp->code && die "Unable to bind to master\n";
+  $mesgp->code && die "Unable to bind to master: Please set ldap_master_root_password\n";
  
   $mesgp = $ldapp->search(
              base    =>  'cn=config',


### PR DESCRIPTION
`zmreplchk` has to query the master LDAP server with the `cn=config` account and requires the master's value of `ldap_root_password`.  If the replica doesn't have the same password set, it doesn't have any way to auto-detect the master's root password.

Syncing the passwords can fail due to [bug 108544](https://bugzilla.zimbra.com/show_bug.cgi?id=108544) though.

This patch introduces an extra localconfig attribute aptly named `ldap_master_root_password`.  The script will still fall back to `ldap_root_password` if that value isn't set.

It also improves the error message when the bind to the master fails.