### PR TITLE
feature/ZCS-4459

### DIFF
--- a/src/libexec/zmupdatedownload
+++ b/src/libexec/zmupdatedownload
@@ -22,7 +22,7 @@ usage() {
   exit 1
 }
 
-if [ x`whoami` != xzimbra ]; then
+if [ "$(whoami)" != "zimbra" ]; then
   echo Error: must be run as zimbra user
   exit 1
 fi
@@ -30,33 +30,38 @@ fi
 source /opt/zimbra/bin/zmshutil || exit 1
 zmsetvars
 
+# shellcheck disable=SC2154
 download_dir=${mailboxd_directory}/webapps/zimbra/downloads
 index=${download_dir}/index.html
 
 admin_dir=${mailboxd_directory}/webapps/zimbraAdmin/WEB-INF/classes/messages
 zmsg=${admin_dir}/ZaMsg.properties
 
-if [ -d "${download_dir}" ]; then
-  ZCO_32BIT=$(cd ${download_dir}; ls -tr1 ZimbraConnectorOLK*x86.msi 2>/dev/null | tail -1)
-  ZCO_64BIT=$(cd ${download_dir}; ls -tr1 ZimbraConnectorOLK*x64.msi 2>/dev/null | tail -1)
-  PST_IMPORT=$(cd ${download_dir}; ls -tr1 ZCSPSTImportWizard* 2>/dev/null | tail -1)
-  EXCHANGE_MIG_WIZARD=$(cd ${download_dir}; ls -tr1 ZCSExchangeMigrationWizard* 2>/dev/null | tail -1)
-  DOMINO_MIG_WIZARD=$(cd ${download_dir}; ls -tr1 ZCSDominoMigrationWizard* 2>/dev/null | tail -1)
-  GENERAL_MIG_WIZARD_32BIT=$(cd ${download_dir}; ls -tr1 ZimbraMigration_*_x86.zip 2>/dev/null | tail -1)
-  GENERAL_MIG_WIZARD_64BIT=$(cd ${download_dir}; ls -tr1 ZimbraMigration_*_x64.zip 2>/dev/null | tail -1)
+function find_download_filename {
+    fname="$1"
+    find "${download_dir}" -name "$fname" -exec basename '{}' \;
+}
 
-  cat ${index}.in | \
-    sed -e "s/@@ZCO_32BIT@@/${ZCO_32BIT}/" \
-    -e "s/@@ZCO_64BIT@@/${ZCO_64BIT}/" \
-    -e "s/@@PST_IMPORT@@/${PST_IMPORT}/" \
-    -e "s/@@EXCHANGE_MIG_WIZARD@@/${EXCHANGE_MIG_WIZARD}/" \
-    -e "s/@@GENERAL_MIG_WIZARD_32BIT@@/${GENERAL_MIG_WIZARD_32BIT}/" \
-    -e "s/@@GENERAL_MIG_WIZARD_64BIT@@/${GENERAL_MIG_WIZARD_64BIT}/" \
-    -e "s/@@DOMINO_MIG_WIZARD@@/${DOMINO_MIG_WIZARD}/" > ${index}
+if [ -d "${download_dir}" ]; then
+  ZCO_32BIT=$(find_download_filename "ZimbraConnectorOLK*x86.msi")
+  ZCO_64BIT=$(find_download_filename "ZimbraConnectorOLK*x64.msi")
+  PST_IMPORT=$(find_download_filename "ZCSPSTImportWizard*")
+  EXCHANGE_MIG_WIZARD=$(find_download_filename "ZCSExchangeMigrationWizard*")
+  DOMINO_MIG_WIZARD=$(find_download_filename "ZCSDominoMigrationWizard*")
+  GENERAL_MIG_WIZARD_32BIT=$(find_download_filename "ZimbraMigration_*_x86.zip")
+  GENERAL_MIG_WIZARD_64BIT=$(find_download_filename "ZimbraMigration_*_x64.zip")
+
+  sed -e "s/@@ZCO_32BIT@@/${ZCO_32BIT}/" \
+  -e "s/@@ZCO_64BIT@@/${ZCO_64BIT}/" \
+  -e "s/@@PST_IMPORT@@/${PST_IMPORT}/" \
+  -e "s/@@EXCHANGE_MIG_WIZARD@@/${EXCHANGE_MIG_WIZARD}/" \
+  -e "s/@@GENERAL_MIG_WIZARD_32BIT@@/${GENERAL_MIG_WIZARD_32BIT}/" \
+  -e "s/@@GENERAL_MIG_WIZARD_64BIT@@/${GENERAL_MIG_WIZARD_64BIT}/" \
+  -e "s/@@DOMINO_MIG_WIZARD@@/${DOMINO_MIG_WIZARD}/" > "${index}" < "${index}.in"
 
   if [ -f "${zmsg}" ]; then
     sed -i -e "s#ZimbraConnectorOLK_.*x86.msi#${ZCO_32BIT}#" \
-      -e "s#ZimbraConnectorOLK_.*x64.msi#${ZCO_64BIT}#" ${zmsg}
+      -e "s#ZimbraConnectorOLK_.*x64.msi#${ZCO_64BIT}#" "${zmsg}"
   fi
 fi
 

--- a/src/libexec/zmupdatedownload
+++ b/src/libexec/zmupdatedownload
@@ -38,8 +38,34 @@ admin_dir=${mailboxd_directory}/webapps/zimbraAdmin/WEB-INF/classes/messages
 zmsg=${admin_dir}/ZaMsg.properties
 
 function find_download_filename {
-    fname="$1"
-    find "${download_dir}" -name "$fname" -exec basename '{}' \;
+  fname="$1"
+  find "${download_dir}" -name "$fname" -exec basename '{}' \;
+}
+
+function append_download_if_missing {
+  key="$1"
+  val="$2"
+
+  grep -q -E "\<${key}\>" "${zmsg}"
+  if [ $? -ne 0 ]; then
+    echo "${key} = ${val}" >> "${zmsg}"
+  fi
+}
+
+# shellcheck disable=SC2034
+function populate_downloads_to_append {
+  CONNECTOR_MSI_DOWNLOAD_LINK=$(find_download_filename "ZmCustomizeMsi.js")
+  ZCO_BRANDING_DOWNLOAD_LINK=$(find_download_filename "ZimbraBrandMsi.vbs")
+  CONNECTOR_64_DOWNLOAD_LINK=$(find_download_filename "ZimbraConnectorOLK_*_x64.msi")
+  CONNECTOR_UNSIGNED_64_DOWNLOAD_LINK=$(find_download_filename "ZimbraConnectorOLK_*_x64-UNSIGNED.msi")
+  CONNECTOR_32_DOWNLOAD_LINK=$(find_download_filename "ZimbraConnectorOLK_*_x86.msi")
+  CONNECTOR_UNSIGNED_32_DOWNLOAD_LINK=$(find_download_filename "ZimbraConnectorOLK_*_x86-UNSIGNED.msi")
+  GENERAL_MIG_WIZ_X64_DOWNLOAD_LINK=$(find_download_filename "ZimbraMigration_*_x64.zip")
+  GENERAL_MIG_WIZ_X86_DOWNLOAD_LINK=$(find_download_filename "ZimbraMigration_*_x86.zip")
+  IMPORT_WIZ_DOWNLOAD_LINK=$(find_download_filename "ZCSPSTImportWizard-*.zip")
+  DOMINO_MIG_WIZ_DOWNLOAD_LINK=$(find_download_filename "ZCSDominoMigrationWizard-*.zip")
+  GROUPWISE_MIG_WIZ_DOWNLOAD_LINK=$(find_download_filename "ZCSGroupwiseMigrationWizard-*.exe")
+  MIG_WIZ_DOWNLOAD_LINK=$(find_download_filename "ZCSExchangeMigrationWizard-*.zip")
 }
 
 if [ -d "${download_dir}" ]; then
@@ -50,6 +76,8 @@ if [ -d "${download_dir}" ]; then
   DOMINO_MIG_WIZARD=$(find_download_filename "ZCSDominoMigrationWizard*")
   GENERAL_MIG_WIZARD_32BIT=$(find_download_filename "ZimbraMigration_*_x86.zip")
   GENERAL_MIG_WIZARD_64BIT=$(find_download_filename "ZimbraMigration_*_x64.zip")
+
+  populate_downloads_to_append 
 
   sed -e "s/@@ZCO_32BIT@@/${ZCO_32BIT}/" \
   -e "s/@@ZCO_64BIT@@/${ZCO_64BIT}/" \
@@ -63,6 +91,26 @@ if [ -d "${download_dir}" ]; then
     sed -i -e "s#ZimbraConnectorOLK_.*x86.msi#${ZCO_32BIT}#" \
       -e "s#ZimbraConnectorOLK_.*x64.msi#${ZCO_64BIT}#" "${zmsg}"
   fi
+
+  downloads_to_add=(
+    CONNECTOR_MSI_DOWNLOAD_LINK
+    ZCO_BRANDING_DOWNLOAD_LINK
+    CONNECTOR_64_DOWNLOAD_LINK
+    CONNECTOR_UNSIGNED_64_DOWNLOAD_LINK
+    CONNECTOR_32_DOWNLOAD_LINK
+    CONNECTOR_UNSIGNED_32_DOWNLOAD_LINK
+    GENERAL_MIG_WIZ_X64_DOWNLOAD_LINK
+    GENERAL_MIG_WIZ_X86_DOWNLOAD_LINK
+    IMPORT_WIZ_DOWNLOAD_LINK
+    DOMINO_MIG_WIZ_DOWNLOAD_LINK
+    GROUPWISE_MIG_WIZ_DOWNLOAD_LINK
+    MIG_WIZ_DOWNLOAD_LINK
+  )
+
+  for dl in "${downloads_to_add[@]}"; do
+     # shellcheck disable=SC2046
+     append_download_if_missing "${dl}" $(eval echo "\$$dl")
+  done
 fi
 
 exit 0


### PR DESCRIPTION
Updated the `zmupdatedownload` script to replace the functionality that was removed from the `zimbra-store` package as part of the work that was done [here](https://github.com/Zimbra/zm-build/pull/90/commits/5f42c93f9ad57b172483bcdfc0e0efe64ff0fc9b) for ZCS-4351.

I would recommend that you examine the two commits individually.  The _first_ commit consists only of updates that was done to fix all [shellcheck](https://github.com/koalaman/shellcheck) warnings.

The second commit adds the new functionality.