### PR TITLE
ZBUG-151zmfixperms postfix data ++

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -100,8 +100,14 @@ if [ ${extended} = "yes" ]; then
   chown -R ${zimbra_user}:${zimbra_group} /opt/zimbra/a* /opt/zimbra/[c-hj-ot-z]* /opt/zimbra/s[a-su-z]* 2> /dev/null
 fi
 
+chown ${root_user}:${root_group} /opt
+chmod 755 /opt
+chown ${root_user}:${root_group} /opt/zimbra
+chmod 755 /opt/zimbra
 chown -R ${root_user}:${root_group} /opt/zimbra/common
+chmod 755 /opt/zimbra/common
 chown -R ${root_user}:${zimbra_group} /opt/zimbra/common/conf
+chmod 775 /opt/zimbra/common/conf
 
 for i in master.cf master.cf.in bysender bysender.lmdb tag_as_foreign.re tag_as_foreign.re.in tag_as_originating.re tag_as_originating.re.in;
 do
@@ -631,7 +637,10 @@ if [ -d /opt/zimbra/data/postfix ]; then
   chown -f ${postfix_owner} /opt/zimbra/data/postfix
   chown -f ${postfix_owner} /opt/zimbra/data/postfix/* 2> /dev/null
   chgrp -f ${postfix_suid_group} /opt/zimbra/data/postfix/data
+  chmod 755 /opt/zimbra/data/postfix/data
   chown -f ${postfix_owner}:${postfix_owner} /opt/zimbra/data/postfix/data/* 2> /dev/null
+  # `postfix check` checks that everything under data is not group or other writable
+  chmod -R go-w /opt/zimbra/data/postfix/data
   chown -f ${root_user} /opt/zimbra/data/postfix/spool
   chgrp -f ${root_group} /opt/zimbra/data/postfix/spool
 fi


### PR DESCRIPTION
* Fix perms of /opt/zimbra/data/postfix/data
* Ensure everything under /opt/zimbra/data/postfix/data is not writable at
  group or other level
* Fix ownership and perms of /opt
* Fix ownership and perms of /opt/zimbra
* Fix perms of /opt/zimbra/common
* Fix perms of /opt/zimbra/common/conf