### PR TITLE
NICPS-19 : corrected SearchDirectoryRequest to make --searchdirectory option work

### DIFF
--- a/src/libexec/zmsearchndelete
+++ b/src/libexec/zmsearchndelete
@@ -143,7 +143,7 @@ See also L<Input File Format>.
 
 LDAP filter used to search the directory for accounts.  The search is
 performed via ZCS Admin SOAP SearchDirectoryRequest and uses the
-default 'types=account' to only match accounts.  This option is not
+default 'types=accounts' to only match accounts.  This option is not
 allowed when using the --noadminauth option.
 
 Examples:
@@ -453,7 +453,7 @@ sub searchdirectory {
     my $limit = 50;
     my $attr  = {
         xmlns      => NS_ZADMIN,
-        types      => "account",
+        types      => "accounts",
         limit      => $limit,
         attrs      => "mail",
         applyCos   => 0,


### PR DESCRIPTION
**Problem :** --searchdirectory option is not working in zmsearchndelete
**Fix :** In SearchDirectoryRequest one of the parameters is "types=accounts" but in script it is "types=account". Corrected the same.
**Testing done :** Tested script with --searchdirectory option.
**Testing needs to be done by QA :** extensively check all the script options with all possible values.