### PR TITLE
NICPS-19 : Added message to indicate deletion

### DIFF
--- a/src/libexec/zmsearchndelete
+++ b/src/libexec/zmsearchndelete
@@ -288,7 +288,12 @@ sub main {
         $Opt{go}
     );
 
-    warn("$Prog: info: Total messages found for given query: $cnt \n");
+    my $msg = "$Prog: info: Total messages found";
+    if ($Opt{go}) {
+        $msg .= " and deleted";
+    }
+    $msg .= " for given query: $cnt";
+    warn("$msg \n");
 
     my $tEnd = Benchmark->new;
 

--- a/src/libexec/zmsearchndelete
+++ b/src/libexec/zmsearchndelete
@@ -289,7 +289,7 @@ sub main {
     );
 
     my $msg = "$Prog: info: Total messages found";
-    if ($Opt{go}) {
+    if ( $Opt{go} ) {
         $msg .= " and deleted";
     }
     $msg .= " for given query: $cnt";


### PR DESCRIPTION
**Problem :** --go option do deletion but no message is displayed about deletion.
**Fix :** Added message to indicate deletion when --go option is used.
**Testing done :** Tested with and without using --go option and appropriate message is displayed.

Without --go option
```
/opt/zimbra/libexec/zmsearchndelete --url https://`zmhostname`:7071/service/admin/soap/ --authuser admin@`zmhostname` --password test123 --query "asdf" --searchdirectory 'mail=*'
zmsearchndelete: info: use '--go' option to actually DELETE matched messages
zmsearchndelete: info: started 18 Apr 2018 14:21:42 +0530 (IST)
zmsearchndelete: info: total accounts: 7
zmsearchndelete: info: query: asdf
zmsearchndelete: info: searching messages now: 18 Apr 2018 14:21:43 +0530 (IST)
zmsearchndelete: info: processing searched messages now: 18 Apr 2018 14:21:43 +0530 (IST)
------------------------
    1:Account	2:MSG_ID	3:CONV_ID	4:DATE(mm/dd/yy)	5:FROM	6:SIZE(Bytes)
------------------------
zmsearchndelete: info: Total messages found for given query: 0 
zmsearchndelete: info: finished 18 Apr 2018 14:21:43 +0530 (IST)
zmsearchndelete: info: took  1 wallclock secs ( 0.38 usr +  0.03 sys =  0.41 CPU)
```

With --go option
```
/opt/zimbra/libexec/zmsearchndelete --url https://`zmhostname`:7071/service/admin/soap/ --authuser admin@`zmhostname` --password test123 --query "asdf" --searchdirectory 'mail=*' --go
zmsearchndelete: info: started 18 Apr 2018 13:54:58 +0530 (IST)
zmsearchndelete: info: total accounts: 7
zmsearchndelete: info: query: asdf
zmsearchndelete: info: searching messages now: 18 Apr 2018 13:54:59 +0530 (IST)
zmsearchndelete: info: processing searched messages now: 18 Apr 2018 13:54:59 +0530 (IST)
------------------------
    1:Account	2:MSG_ID	3:CONV_ID	4:DATE(mm/dd/yy)	5:FROM	6:SIZE(Bytes)
------------------------
zmsearchndelete: info: Total messages found and deleted for given query: 0 
zmsearchndelete: info: finished 18 Apr 2018 13:54:59 +0530 (IST)
zmsearchndelete: info: took  1 wallclock secs ( 0.38 usr +  0.02 sys =  0.40 CPU)
```

**Testing to be done by QA :** 
Verify output with and without --go option.