### PR TITLE
Set permissions for conf/templates directory.

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -293,6 +293,35 @@ if [ -d /opt/zimbra ]; then
       chmod 640 /opt/zimbra/conf/sasl2/smtpd.conf
       chown ${zimbra_user}:${zimbra_group} /opt/zimbra/conf/sasl2/smtpd.conf
     fi
+    
+    if [ -d /opt/zimbra/conf/templates/ ]; then
+      chmod 755 /opt/zimbra/conf/templates
+      chown ${zimbra_user}:${zimbra_group} /opt/zimbra/conf/templates
+      
+      chmod 755 \
+        /opt/zimbra/conf/templates /opt/zimbra/conf/templates/abook /opt/zimbra/conf/templates/briefcase \
+        /opt/zimbra/conf/templates/calendar /opt/zimbra/conf/templates/data /opt/zimbra/conf/templates/dwt \
+        /opt/zimbra/conf/templates/mail /opt/zimbra/conf/templates/prefs /opt/zimbra/conf/templates/share \
+        /opt/zimbra/conf/templates/tasks /opt/zimbra/conf/templates/voicemail /opt/zimbra/conf/templates/zimbra
+
+      chown ${zimbra_user}:${zimbra_group} \
+        /opt/zimbra/conf/templates /opt/zimbra/conf/templates/abook /opt/zimbra/conf/templates/briefcase \
+        /opt/zimbra/conf/templates/calendar /opt/zimbra/conf/templates/data /opt/zimbra/conf/templates/dwt \
+        /opt/zimbra/conf/templates/mail /opt/zimbra/conf/templates/prefs /opt/zimbra/conf/templates/share \
+        /opt/zimbra/conf/templates/tasks /opt/zimbra/conf/templates/voicemail /opt/zimbra/conf/templates/zimbra
+
+      chmod 644 \
+        /opt/zimbra/conf/templates/abook/* /opt/zimbra/conf/templates/admin/* /opt/zimbra/conf/templates/briefcase/* \
+        /opt/zimbra/conf/templates/calendar/* /opt/zimbra/conf/templates/data/* /opt/zimbra/conf/templates/dwt/* \
+        /opt/zimbra/conf/templates/mail/* /opt/zimbra/conf/templates/prefs/* /opt/zimbra/conf/templates/share/* \
+        /opt/zimbra/conf/templates/tasks/* /opt/zimbra/conf/templates/voicemail/* /opt/zimbra/conf/templates/zimbra/*
+        
+      chown ${zimbra_user}:${zimbra_group} \
+        /opt/zimbra/conf/templates/abook/* /opt/zimbra/conf/templates/admin/* /opt/zimbra/conf/templates/briefcase/* \
+        /opt/zimbra/conf/templates/calendar/* /opt/zimbra/conf/templates/data/* /opt/zimbra/conf/templates/dwt/* \
+        /opt/zimbra/conf/templates/mail/* /opt/zimbra/conf/templates/prefs/* /opt/zimbra/conf/templates/share/* \
+        /opt/zimbra/conf/templates/tasks/* /opt/zimbra/conf/templates/voicemail/* /opt/zimbra/conf/templates/zimbra/*
+    fi
   fi
 
   if [ -d /opt/zimbra/docs ]; then

--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -293,34 +293,11 @@ if [ -d /opt/zimbra ]; then
       chmod 640 /opt/zimbra/conf/sasl2/smtpd.conf
       chown ${zimbra_user}:${zimbra_group} /opt/zimbra/conf/sasl2/smtpd.conf
     fi
-    
+
     if [ -d /opt/zimbra/conf/templates/ ]; then
-      chmod 755 /opt/zimbra/conf/templates
-      chown ${zimbra_user}:${zimbra_group} /opt/zimbra/conf/templates
-      
-      chmod 755 \
-        /opt/zimbra/conf/templates /opt/zimbra/conf/templates/abook /opt/zimbra/conf/templates/briefcase \
-        /opt/zimbra/conf/templates/calendar /opt/zimbra/conf/templates/data /opt/zimbra/conf/templates/dwt \
-        /opt/zimbra/conf/templates/mail /opt/zimbra/conf/templates/prefs /opt/zimbra/conf/templates/share \
-        /opt/zimbra/conf/templates/tasks /opt/zimbra/conf/templates/voicemail /opt/zimbra/conf/templates/zimbra
-
-      chown ${zimbra_user}:${zimbra_group} \
-        /opt/zimbra/conf/templates /opt/zimbra/conf/templates/abook /opt/zimbra/conf/templates/briefcase \
-        /opt/zimbra/conf/templates/calendar /opt/zimbra/conf/templates/data /opt/zimbra/conf/templates/dwt \
-        /opt/zimbra/conf/templates/mail /opt/zimbra/conf/templates/prefs /opt/zimbra/conf/templates/share \
-        /opt/zimbra/conf/templates/tasks /opt/zimbra/conf/templates/voicemail /opt/zimbra/conf/templates/zimbra
-
-      chmod 644 \
-        /opt/zimbra/conf/templates/abook/* /opt/zimbra/conf/templates/admin/* /opt/zimbra/conf/templates/briefcase/* \
-        /opt/zimbra/conf/templates/calendar/* /opt/zimbra/conf/templates/data/* /opt/zimbra/conf/templates/dwt/* \
-        /opt/zimbra/conf/templates/mail/* /opt/zimbra/conf/templates/prefs/* /opt/zimbra/conf/templates/share/* \
-        /opt/zimbra/conf/templates/tasks/* /opt/zimbra/conf/templates/voicemail/* /opt/zimbra/conf/templates/zimbra/*
-        
-      chown ${zimbra_user}:${zimbra_group} \
-        /opt/zimbra/conf/templates/abook/* /opt/zimbra/conf/templates/admin/* /opt/zimbra/conf/templates/briefcase/* \
-        /opt/zimbra/conf/templates/calendar/* /opt/zimbra/conf/templates/data/* /opt/zimbra/conf/templates/dwt/* \
-        /opt/zimbra/conf/templates/mail/* /opt/zimbra/conf/templates/prefs/* /opt/zimbra/conf/templates/share/* \
-        /opt/zimbra/conf/templates/tasks/* /opt/zimbra/conf/templates/voicemail/* /opt/zimbra/conf/templates/zimbra/*
+      chown -R ${zimbra_user}:${zimbra_group} /opt/zimbra/conf/templates
+      find /opt/zimbra/conf/templates/ -type d -exec chmod 755 {} \;
+      find /opt/zimbra/conf/templates/ -type f -exec chmod 644 {} \;
     fi
   fi
 


### PR DESCRIPTION
Since this commit [1] the permissions of conf/templates on redhat/centos aren't properly set and zimbra user cannot read them.
This resulted in breakage of operation of automatic backup of conf/templates/ directory on the NG and ZSP.

[1] https://github.com/Zimbra/zm-build/commit/2a862832591afa3977c29b9382d79be80cd7cd6f#diff-bbb5838c36b21fa969f5cc2fc47b92fe