### PR TITLE
ZBUG-412 Missing Java Class in zmskindeploy

### DIFF
--- a/src/bin/zmskindeploy
+++ b/src/bin/zmskindeploy
@@ -76,7 +76,7 @@ if [ x${BASE_URL} = 'x/' ]; then
   BASE_URL=""
 fi
 
-CP="/opt/zimbra/lib/jars/zimbracommon.jar:${SKIN_WORK_BASE}/WEB-INF/classes"
+CP="/opt/zimbra/lib/jars/zimbracommon.jar:${SKIN_WORK_BASE}/WEB-INF/lib/*"
 
 # Make sure source exists, and copy it to working dir
 if [ -d "$SKIN_SRC" ]; then


### PR DESCRIPTION
- ImageMerger class is missing as it was moved to zm-ajax.jar instead of WEB-INF/classes directory
- include all jar files from WEB-INF/lib directory as classpath