### PR TITLE
NICOPS-46 - Account Deactivation Script

### DIFF
--- a/cron_scripts/config/config.json
+++ b/cron_scripts/config/config.json
@@ -2,7 +2,4 @@
 	"MAILSTOREHOST":"10.139.28.238",
 	"MAILSTOREUSER":"admin@zimbra.nic.in",
 	"MAILSTOREPWD":"root123",
-	"LDAPHOST":"10.139.28.238",
-	"LDAPUSER":"uid=zimbra,cn=admins,cn=zimbra",
-	"LDAPPWD":"y8hBflpX0a"
 }

--- a/cron_scripts/config/config.json
+++ b/cron_scripts/config/config.json
@@ -1,0 +1,8 @@
+{
+	"MAILSTOREHOST":"10.139.28.238",
+	"MAILSTOREUSER":"admin@zimbra.nic.in",
+	"MAILSTOREPWD":"root123",
+	"LDAPHOST":"10.139.28.238",
+	"LDAPUSER":"uid=zimbra,cn=admins,cn=zimbra",
+	"LDAPPWD":"y8hBflpX0a"
+}

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -15,14 +15,16 @@ use POSIX qw(strftime);
 my $config_file = 'config/config.json';
 
 my %opts = (
-	last_login_days => 97
+	last_login_days => 97,
+	new_status => 'locked'
 );
 
 my $res = GetOptions(
 	\%opts,
 	"help",
 	"debug",
-	"last_login_days=i"
+	"last_login_days=i",
+	"new_status=s"
 );
 
 if ($opts{help}) {
@@ -38,6 +40,7 @@ die "MAILSTOREHOST is not defined in config file" if (!defined($config->{MAILSTO
 die "MAILSTOREUSER is not defined in config file" if (!defined($config->{MAILSTOREUSER}) || $config->{MAILSTOREUSER} eq "");
 die "MAILSTOREPWD is not defined in config file" if (!defined($config->{MAILSTOREPWD}) || $config->{MAILSTOREPWD} eq "");
 
+my $new_status = $opts{new_status};
 my $last_login_days = $opts{last_login_days};
 my $last_login_timestamp = strftime('%Y%m%d000000', localtime( time() - $last_login_days*(24 * 60 * 60) ) ) . "Z";
 
@@ -76,7 +79,7 @@ if ($soap_api) {
 	if (scalar @data != 0) {
 		foreach my $acc ( @data ) {
 			my $zimbraId = $acc->{id};
-			my $modify_data = {'zimbraAccountStatus' => 'pending' };
+			my $modify_data = {'zimbraAccountStatus' => $new_status };
 			if ( my $modify_acc = eval { $soap_api->modifyaccount( $zimbraId, $modify_data ) } ) {
 				warn("DEBUG: $acc->{name} made inactive \n") if ($soap_api->Debug);
 			}
@@ -103,5 +106,6 @@ perl $prog_name [options]
 --help    - print this message
 --debug   - print debug message
 --last_login_days - number of days to check for last login
+--new_status - new status to update the user account
 END_PRINT
 }

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -103,7 +103,7 @@ else {
     pod2usage(
         -exitval => 1,
         -msg =>
-"new_status is not acceptable status. Valid status are 'locked','active','pending','lockout','maintenance','closed'"
+"new_status '$opts{new_status}' is invalid, use one of the following: " . join(", ", @allowed_status)
     );
 }
 

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -1,0 +1,110 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib 'lib';
+
+use Getopt::Long;
+use ZCS::API;
+use Data::Dumper;
+use JSON;
+use File::Slurp;
+use POSIX qw(strftime);
+
+my $config_file = 'config/config.json';
+
+my %opts = (
+	last_login_days => 97
+);
+
+my $res = GetOptions(
+	\%opts,
+	"help",
+	"debug",
+	"last_login_days=i"
+);
+
+if ($opts{help}) {
+	print_usage();
+	exit 0;
+} elsif (!$res) {
+	print_usage();
+	exit 1;
+}
+
+my $config = JSON->new->utf8->relaxed->decode(scalar read_file $config_file);
+die "MAILSTOREHOST is not defined in config file" if (!defined($config->{MAILSTOREHOST}) || $config->{MAILSTOREHOST} eq "");
+die "MAILSTOREUSER is not defined in config file" if (!defined($config->{MAILSTOREUSER}) || $config->{MAILSTOREUSER} eq "");
+die "MAILSTOREPWD is not defined in config file" if (!defined($config->{MAILSTOREPWD}) || $config->{MAILSTOREPWD} eq "");
+die "LDAPHOST is not defined in config file" if (!defined($config->{LDAPHOST}) || $config->{LDAPHOST} eq "");
+die "LDAPUSER is not defined in config file" if (!defined($config->{LDAPUSER}) || $config->{LDAPUSER} eq "");
+die "LDAPPWD is not defined in config file" if (!defined($config->{LDAPPWD}) || $config->{LDAPPWD} eq "");
+
+my $last_login_days = $opts{last_login_days};
+my $last_login_timestamp = strftime('%Y%m%d000000', localtime( time() - $last_login_days*(24 * 60 * 60) ) ) . "Z";
+
+my $soap_api = ZCS::API->new(
+	conf => {
+		SOAPURI  => "https://" . $config->{MAILSTOREHOST} . ":7071/service/admin/soap",
+		SOAPUser => $config->{MAILSTOREUSER},
+		SOAPPass => $config->{MAILSTOREPWD},
+	},
+	debug => ($opts{debug}) ? 1 : 0
+);
+
+# search for 'active' accounts whose last login is earlier than specified days $last_login_days
+my @data;
+if ($soap_api) {
+	my %args = (
+		"query" => "(&(zimbraLastLogonTimestamp<=$last_login_timestamp)(zimbraAccountStatus=active)(!(zimbraIsAdminAccount=TRUE)))",
+		"attrs" => "uid,zimbraId,zimbraAccountStatus,zimbraLastLogonTimestamp"
+	);
+
+	if ( my $searched_users = eval { $soap_api->searchdirectory(%args) } ) {
+		my $path = "/Envelope/Body/SearchDirectoryResponse";
+		my $i = 0;
+		foreach my $acc ( $searched_users->dataof("$path/account") ) {
+            $i++;
+            my $msom = $searched_users->match("$path/[$i]")
+              or die("MATCH '$path/[$i]' failed\n");
+
+  		    push @data, $acc->attr;
+        }
+	}
+	else {
+		warn("DEBUG: SearchDirectoryRequest " . $soap_api->Error . " via $config->{MAILSTOREHOST} \n");
+	}
+
+	if (scalar @data != 0) {
+		foreach my $acc ( @data ) {
+			my $zimbraId = $acc->{id};
+			my $modify_data = {'zimbraAccountStatus' => 'pending' };
+			if ( my $modify_acc = eval { $soap_api->modifyaccount( $zimbraId, $modify_data ) } ) {
+				warn("DEBUG: $acc->{name} made inactive \n") if ($soap_api->Debug);
+			}
+			else {
+				warn("DEBUG: ModifyAccountRequest " . $soap_api->Error . " via $config->{MAILSTOREHOST} \n");
+			}
+		}
+	} else {
+		warn("DEBUG: No users found! \n") if ($soap_api->Debug);
+	}
+}
+else {
+	warn(ZCS::API->Error);
+}
+
+
+sub print_usage {
+	my $prog_name = substr($0, rindex($0, '/')+1);
+	print <<END_PRINT;
+This script will go through Zimbra's Internal LDAP and look for any account that has a last login greater than the specified days, the script will change their account status to 'pending' status
+
+Usage:
+perl $prog_name [options]
+--help    - print this message
+--debug   - print debug message
+--last_login_days - number of days to check for last login
+END_PRINT
+}

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -3,41 +3,92 @@
 use strict;
 use warnings;
 
-use lib 'lib';
-
 use Getopt::Long;
-use ZCS::API;
 use Data::Dumper;
 use JSON;
 use File::Slurp;
 use POSIX qw(strftime);
+use Pod::Usage qw(pod2usage);
 
-my $config_file = 'config/config.json';
+=head1 NAME
+
+inactive_idle_accounts.pl - to make idle accounts to inactive status
+
+=head1 SYNOPSIS
+
+  inactive_idle_accounts.pl [-help -debug] -last_login_days <#no. of days> -new_status <#zimbraAccountStatus>
+
+=head1 DESCRIPTION
+
+This script will go through Zimbra's Internal LDAP and look for any account that has a last login greater than the specified days, 
+the script will change their account status to new status that passed to the script
+
+=head1 OPTIONS
+
+=over
+
+=item -help
+
+Prints the help message.
+
+=item -last_login_days
+
+Specifies number of days to check for last login.
+
+=item -new_status
+
+Specifies new status that should be changed to target users.
+
+=item -debug
+
+Enable debug output.
+
+=back
+
+=cut
+
+my $dir_path;
+
+BEGIN {
+    use Cwd 'realpath';
+    ($dir_path) = __FILE__ =~ m{^(.*)/};    # $dir = path of current file
+    $dir_path = realpath($dir_path);
+}
+use lib "$dir_path/lib";
+use ZCS::CustomAPI;
+my $config_file = "$dir_path/config/config.json";
 
 my %opts = (
     last_login_days => 97,
     new_status      => 'locked'
 );
 
-my $res =
-  GetOptions( \%opts, "help", "debug", "last_login_days=i", "new_status=s" );
+GetOptions( \%opts, "help", "debug", "last_login_days=i", "new_status=s" )
+  or pod2usage( -verbose => 99, -sections => "SYNOPSIS", -exitval => 1 );
 
-if ( $opts{help} ) {
-    print_usage();
-    exit 0;
-}
-elsif ( !$res ) {
-    print_usage();
-    exit 1;
-}
+pod2usage(1) if ( $opts{help} );
 
 my $config = JSON->new->utf8->relaxed->decode( scalar read_file $config_file);
-die "MAILSTOREHOST is not defined in config file"
-  if ( !defined( $config->{MAILSTOREHOST} ) || $config->{MAILSTOREHOST} eq "" );
-die "MAILSTOREUSER is not defined in config file"
-  if ( !defined( $config->{MAILSTOREUSER} ) || $config->{MAILSTOREUSER} eq "" );
-die "MAILSTOREPWD is not defined in config file"
-  if ( !defined( $config->{MAILSTOREPWD} ) || $config->{MAILSTOREPWD} eq "" );
+unless ( defined( $config->{MAILSTOREHOST} ) && $config->{MAILSTOREHOST} ne "" )
+{
+    pod2usage(
+        -exitval => 1,
+        -msg     => "MAILSTOREHOST is not defined in config file."
+    );
+}
+unless ( defined( $config->{MAILSTOREUSER} ) && $config->{MAILSTOREUSER} ne "" )
+{
+    pod2usage(
+        -exitval => 1,
+        -msg     => "MAILSTOREUSER is not defined in config file."
+    );
+}
+unless ( defined( $config->{MAILSTOREPWD} ) && $config->{MAILSTOREPWD} ne "" ) {
+    pod2usage(
+        -exitval => 1,
+        -msg     => "MAILSTOREPWD is not defined in config file."
+    );
+}
 
 my $new_status      = $opts{new_status};
 my $last_login_days = $opts{last_login_days};
@@ -46,7 +97,7 @@ my $last_login_timestamp =
     localtime( time() - $last_login_days * ( 24 * 60 * 60 ) ) )
   . "Z";
 
-my $soap_api = ZCS::API->new(
+my $soap_api = ZCS::CustomAPI->new(
     conf => {
         SOAPURI => "https://"
           . $config->{MAILSTOREHOST}
@@ -78,9 +129,12 @@ if ($soap_api) {
         }
     }
     else {
-        warn(   "DEBUG: SearchDirectoryRequest "
-              . $soap_api->Error
-              . " via $config->{MAILSTOREHOST} \n" );
+        pod2usage(
+            -exitval => 1,
+            -msg     => "SearchDirectoryRequest: "
+              . $soap_api->Error . " via "
+              . $config->{MAILSTOREHOST}
+        );
     }
 
     if ( scalar @data != 0 ) {
@@ -90,13 +144,15 @@ if ($soap_api) {
             if ( my $modify_acc =
                 eval { $soap_api->modifyaccount( $zimbraId, $modify_data ) } )
             {
-                warn("DEBUG: $acc->{name} made inactive \n")
+                warn("DEBUG: $acc->{name} made inactive\n")
                   if ( $soap_api->Debug );
             }
             else {
-                warn(   "DEBUG: ModifyAccountRequest "
-                      . $soap_api->Error
-                      . " via $config->{MAILSTOREHOST} \n" );
+                pod2usage( -msg => "ModifyAccountRequest: "
+                      . $soap_api->Error . " via "
+                      . $config->{MAILSTOREHOST}
+                      . "for user: "
+                      . $acc->{name} );
             }
         }
     }
@@ -105,18 +161,8 @@ if ($soap_api) {
     }
 }
 else {
-    warn( ZCS::API->Error );
-}
-
-sub print_usage {
-    my $prog_name = substr( $0, rindex( $0, '/' ) + 1 );
-    print <<END_PRINT;
-This script will go through Zimbra's Internal LDAP and look for any account that has a last login greater than the specified days, the script will change their account status to 'pending' status
-
-Usage:
-perl $prog_name [options]
---help    - print this message
---debug   - print debug message
---last_login_days - number of days to check for last login
-END_PRINT
+    pod2usage(
+        -exitval => 1,
+        -msg     => ZCS::CustomAPI->Error
+    );
 }

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -15,90 +15,102 @@ use POSIX qw(strftime);
 my $config_file = 'config/config.json';
 
 my %opts = (
-	last_login_days => 97,
-	new_status => 'locked'
+    last_login_days => 97,
+    new_status      => 'locked'
 );
 
-my $res = GetOptions(
-	\%opts,
-	"help",
-	"debug",
-	"last_login_days=i",
-	"new_status=s"
-);
+my $res =
+  GetOptions( \%opts, "help", "debug", "last_login_days=i", "new_status=s" );
 
-if ($opts{help}) {
-	print_usage();
-	exit 0;
-} elsif (!$res) {
-	print_usage();
-	exit 1;
+if ( $opts{help} ) {
+    print_usage();
+    exit 0;
+}
+elsif ( !$res ) {
+    print_usage();
+    exit 1;
 }
 
-my $config = JSON->new->utf8->relaxed->decode(scalar read_file $config_file);
-die "MAILSTOREHOST is not defined in config file" if (!defined($config->{MAILSTOREHOST}) || $config->{MAILSTOREHOST} eq "");
-die "MAILSTOREUSER is not defined in config file" if (!defined($config->{MAILSTOREUSER}) || $config->{MAILSTOREUSER} eq "");
-die "MAILSTOREPWD is not defined in config file" if (!defined($config->{MAILSTOREPWD}) || $config->{MAILSTOREPWD} eq "");
+my $config = JSON->new->utf8->relaxed->decode( scalar read_file $config_file);
+die "MAILSTOREHOST is not defined in config file"
+  if ( !defined( $config->{MAILSTOREHOST} ) || $config->{MAILSTOREHOST} eq "" );
+die "MAILSTOREUSER is not defined in config file"
+  if ( !defined( $config->{MAILSTOREUSER} ) || $config->{MAILSTOREUSER} eq "" );
+die "MAILSTOREPWD is not defined in config file"
+  if ( !defined( $config->{MAILSTOREPWD} ) || $config->{MAILSTOREPWD} eq "" );
 
-my $new_status = $opts{new_status};
+my $new_status      = $opts{new_status};
 my $last_login_days = $opts{last_login_days};
-my $last_login_timestamp = strftime('%Y%m%d000000', localtime( time() - $last_login_days*(24 * 60 * 60) ) ) . "Z";
+my $last_login_timestamp =
+  strftime( '%Y%m%d000000',
+    localtime( time() - $last_login_days * ( 24 * 60 * 60 ) ) )
+  . "Z";
 
 my $soap_api = ZCS::API->new(
-	conf => {
-		SOAPURI  => "https://" . $config->{MAILSTOREHOST} . ":7071/service/admin/soap",
-		SOAPUser => $config->{MAILSTOREUSER},
-		SOAPPass => $config->{MAILSTOREPWD},
-	},
-	debug => ($opts{debug}) ? 1 : 0
+    conf => {
+        SOAPURI => "https://"
+          . $config->{MAILSTOREHOST}
+          . ":7071/service/admin/soap",
+        SOAPUser => $config->{MAILSTOREUSER},
+        SOAPPass => $config->{MAILSTOREPWD},
+    },
+    debug => ( $opts{debug} ) ? 1 : 0
 );
 
 # search for 'active' accounts whose last login is earlier than specified days $last_login_days
 my @data;
 if ($soap_api) {
-	my %args = (
-		"query" => "(&(zimbraLastLogonTimestamp<=$last_login_timestamp)(zimbraAccountStatus=active)(!(zimbraIsAdminAccount=TRUE)))",
-		"attrs" => "uid,zimbraId,zimbraAccountStatus,zimbraLastLogonTimestamp"
-	);
+    my %args = (
+        "query" =>
+"(&(zimbraLastLogonTimestamp<=$last_login_timestamp)(zimbraAccountStatus=active)(!(zimbraIsAdminAccount=TRUE)))",
+        "attrs" => "uid,zimbraId,zimbraAccountStatus,zimbraLastLogonTimestamp"
+    );
 
-	if ( my $searched_users = eval { $soap_api->searchdirectory(%args) } ) {
-		my $path = "/Envelope/Body/SearchDirectoryResponse";
-		my $i = 0;
-		foreach my $acc ( $searched_users->dataof("$path/account") ) {
+    if ( my $searched_users = eval { $soap_api->searchdirectory(%args) } ) {
+        my $path = "/Envelope/Body/SearchDirectoryResponse";
+        my $i    = 0;
+        foreach my $acc ( $searched_users->dataof("$path/account") ) {
             $i++;
             my $msom = $searched_users->match("$path/[$i]")
               or die("MATCH '$path/[$i]' failed\n");
 
-  		    push @data, $acc->attr;
+            push @data, $acc->attr;
         }
-	}
-	else {
-		warn("DEBUG: SearchDirectoryRequest " . $soap_api->Error . " via $config->{MAILSTOREHOST} \n");
-	}
+    }
+    else {
+        warn(   "DEBUG: SearchDirectoryRequest "
+              . $soap_api->Error
+              . " via $config->{MAILSTOREHOST} \n" );
+    }
 
-	if (scalar @data != 0) {
-		foreach my $acc ( @data ) {
-			my $zimbraId = $acc->{id};
-			my $modify_data = {'zimbraAccountStatus' => $new_status };
-			if ( my $modify_acc = eval { $soap_api->modifyaccount( $zimbraId, $modify_data ) } ) {
-				warn("DEBUG: $acc->{name} made inactive \n") if ($soap_api->Debug);
-			}
-			else {
-				warn("DEBUG: ModifyAccountRequest " . $soap_api->Error . " via $config->{MAILSTOREHOST} \n");
-			}
-		}
-	} else {
-		warn("DEBUG: No users found! \n") if ($soap_api->Debug);
-	}
+    if ( scalar @data != 0 ) {
+        foreach my $acc (@data) {
+            my $zimbraId = $acc->{id};
+            my $modify_data = { 'zimbraAccountStatus' => $new_status };
+            if ( my $modify_acc =
+                eval { $soap_api->modifyaccount( $zimbraId, $modify_data ) } )
+            {
+                warn("DEBUG: $acc->{name} made inactive \n")
+                  if ( $soap_api->Debug );
+            }
+            else {
+                warn(   "DEBUG: ModifyAccountRequest "
+                      . $soap_api->Error
+                      . " via $config->{MAILSTOREHOST} \n" );
+            }
+        }
+    }
+    else {
+        warn("DEBUG: No users found! \n") if ( $soap_api->Debug );
+    }
 }
 else {
-	warn(ZCS::API->Error);
+    warn( ZCS::API->Error );
 }
 
-
 sub print_usage {
-	my $prog_name = substr($0, rindex($0, '/')+1);
-	print <<END_PRINT;
+    my $prog_name = substr( $0, rindex( $0, '/' ) + 1 );
+    print <<END_PRINT;
 This script will go through Zimbra's Internal LDAP and look for any account that has a last login greater than the specified days, the script will change their account status to 'pending' status
 
 Usage:
@@ -106,6 +118,5 @@ perl $prog_name [options]
 --help    - print this message
 --debug   - print debug message
 --last_login_days - number of days to check for last login
---new_status - new status to update the user account
 END_PRINT
 }

--- a/cron_scripts/inactive_idle_accounts.pl
+++ b/cron_scripts/inactive_idle_accounts.pl
@@ -37,9 +37,6 @@ my $config = JSON->new->utf8->relaxed->decode(scalar read_file $config_file);
 die "MAILSTOREHOST is not defined in config file" if (!defined($config->{MAILSTOREHOST}) || $config->{MAILSTOREHOST} eq "");
 die "MAILSTOREUSER is not defined in config file" if (!defined($config->{MAILSTOREUSER}) || $config->{MAILSTOREUSER} eq "");
 die "MAILSTOREPWD is not defined in config file" if (!defined($config->{MAILSTOREPWD}) || $config->{MAILSTOREPWD} eq "");
-die "LDAPHOST is not defined in config file" if (!defined($config->{LDAPHOST}) || $config->{LDAPHOST} eq "");
-die "LDAPUSER is not defined in config file" if (!defined($config->{LDAPUSER}) || $config->{LDAPUSER} eq "");
-die "LDAPPWD is not defined in config file" if (!defined($config->{LDAPPWD}) || $config->{LDAPPWD} eq "");
 
 my $last_login_days = $opts{last_login_days};
 my $last_login_timestamp = strftime('%Y%m%d000000', localtime( time() - $last_login_days*(24 * 60 * 60) ) ) . "Z";

--- a/cron_scripts/lib/ZCS/API.pm
+++ b/cron_scripts/lib/ZCS/API.pm
@@ -1,0 +1,363 @@
+package ZCS::API;
+
+use strict;
+use warnings;
+
+use SOAP::Lite ();
+use Data::Dumper;
+
+our $Debug = 0;
+our $Error = '';
+
+BEGIN {
+    # avoid self signed SSL certificate rejection
+    $ENV{"PERL_LWP_SSL_VERIFY_HOSTNAME"} = 0;
+
+    # avoid default SSL_verify_mode SSL_VERIFY_NONE deprecated warning
+    use LWP::Protocol::http ();
+    @LWP::Protocol::http::EXTRA_SOCK_OPTS = ( SSL_verify_mode => 0 );
+}
+
+sub new {
+    my $class = shift;
+    die("new: invalid arguments\n") if ( @_ % 2 );
+
+    my $self = bless( {}, ref($class) || $class );
+    my @args = @_;
+    my ( $err, $key, $val );
+    for ( my $i = 0 ; $i < $#args ; $i += 2 ) {
+        ( $key, $val ) = ( $args[$i], $args[ $i + 1 ] );
+        local ($@);
+        eval {
+            my $func = "arg_$key";
+            $self->$func($val);
+        };
+        $err = $@;
+        last if $err;
+    }
+    if ($err) {
+        chomp($err);
+        die("new: $key($val) failed: $err\n");
+    }
+
+    # attempt to populate conf via ENV if necessary
+    $self->conf( {} ) unless ( $self->conf );
+
+    return $self;
+}
+
+sub arg_conf  { shift->conf(@_); }
+sub arg_debug { shift->Debug(@_); }
+
+sub Debug {
+    $Debug = $_[1] if ( @_ > 1 );
+    return $Debug;
+}
+sub Error {
+    $Error = $_[1] if ( @_ > 1 );
+    return $Error;
+}
+
+sub conf_keys      { return qw(SOAPURI SOAPUser SOAPPass); }
+
+sub conf {
+    my ( $self, $conf ) = @_;
+    if ( @_ > 1 ) {
+        die("conf not a HASHREF\n") unless ( ref($conf) eq "HASH" );
+        my @req = $self->conf_keys;
+        my @err;
+        foreach my $k (@req) {
+            push( @err, $k ) unless ( defined($conf->{$k}) );
+        }
+        die( ref($self) . "->conf: missing info: ", join( ", ", @err ), "\n" )
+          if @err;
+        $self->{_conf} = $conf;
+    }
+    return $self->{_conf};
+}
+
+sub soap {
+    my $self = shift;
+    unless ( exists( $self->{_soap} ) ) {
+        #SOAP::Lite->import( +trace => "all" ) if $self->Debug;
+        $self->{_soap} = SOAP::Lite->new(
+            proxy    => $self->conf->{SOAPURI},
+            autotype => 0
+        );
+    }
+    return $self->{_soap};
+}
+
+sub soap_call {
+    my $self = shift;
+    my %opt  = @_;
+
+    my $req = SOAP::Data->name( $opt{req} );
+    $req->attr( $opt{attr} ) if $opt{attr};
+
+    my @body = ref $opt{body} eq "ARRAY" ? @{ $opt{body} } : ( $opt{body} );
+    my $resp;
+
+    my ( $err, $try, $maxtry, $sec ) = ( undef, 0, 3, 0 );
+    while ( !$resp && $try++ < $maxtry ) {
+        local ($@);
+        eval { $resp = $self->soap->call( $req, $opt{head}, @body ); };
+        $err = $@;
+        if (_err($resp) =~ /Client auth credentials have expired/) {
+              # reauthenticate for long running processes
+              $opt{head} = $self->reauth($opt{head});
+              $resp=undef; # force retry
+        } elsif ($err) {
+            chomp($err);
+            last unless ( $try < $maxtry );
+            $sec += $try;    # back off a little more on each retry
+            warn("soap_call $opt{req}: sleep($sec): try#$try error: $err\n");
+            sleep($sec);
+        }
+    }
+
+    if ( $err || $resp->fault ) {
+        $self->Error( "error: $opt{req}"
+              . ( $try > 1 ? " (try #$try)" : "" ) . ": "
+              . ( $err || _err($resp) ) );
+        return undef;
+    }
+
+    return $resp;
+}
+
+sub _err {
+    my ($resp) = @_;
+    return ("no response object") unless ($resp);
+    if ( $resp->fault ) {
+        return (
+            (
+                     $resp->faultcode
+                  || $resp->valueof('/Envelope/Body/Fault/Detail/Error/Code')
+            )
+            . " "
+              . (
+                     $resp->faultstring
+                  || $resp->valueof('/Envelope/Body/Fault/Reason/Text')
+              )
+              . (
+                $Debug
+                ? ( "; "
+                      . $resp->fault->{detail}->{Error}->{Code} . ": "
+                      . $resp->fault->{detail}->{Error}->{Trace} )
+                : ""
+              )
+        );
+    }
+    if (defined($resp->valueof("//Fault/faultcode"))) {
+        return (
+                $resp->valueof("//Fault/faultcode") . " "
+              . $resp->valueof("//Fault/faultstring")
+              . (
+                $Debug
+                ? ( "; "
+                      . $resp->valueof('//Fault/detail/Error/Code') . ": "
+                      . $resp->valueof('//Fault/detail/Error/Trace') )
+                : ""
+              )
+        );
+    }
+}
+
+# expect no issues with token expiring
+sub auth {
+    my $self = shift;
+    unless ( exists( $self->{_zimbra_auth} ) ) {
+
+        # authenticate with zimbra to get AuthToken
+        my $req = "AuthRequest";
+        my $attr = { "xmlns" => "urn:zimbraAdmin" };
+        my $head =
+          SOAP::Header->name("context")->attr( { "xmlns" => "urn:zimbra" } );
+        my $body = [
+            SOAP::Data->name( name => $self->conf->{SOAPUser} )->type("string"),
+            SOAP::Data->name( password => $self->conf->{SOAPPass} )
+              ->type("string")
+        ];
+
+        my $resp = $self->soap_call(
+            req  => $req,
+            attr => $attr,
+            head => $head,
+            body => $body
+        );
+        die $self->Error unless $resp;
+
+        # Convert authToken into value that can be passed to zimbra requests
+        # and cache for all future requests
+        $self->{_zimbra_auth} = SOAP::Header->name(
+            "context" => \SOAP::Header->value(
+                SOAP::Header->name(
+                    "authToken" => $resp->valueof('//authToken')
+                ),
+            )
+        )->attr( { xmlns => "urn:zimbra" } );
+    }
+    return $self->{_zimbra_auth};
+}
+
+sub delegateauth {
+    my ( $self, $account ) = @_;
+
+    unless ( exists( $self->{_zimbra_delegateauth}{$account} ) ) {
+
+        # authenticate with zimbra to get AuthToken
+        my $req = "DelegateAuthRequest";
+        my $attr = { "xmlns" => "urn:zimbraAdmin" };
+        my $body =
+          SOAP::Data->name( account => $account )->type("string")
+          ->attr( { by => "name" } );
+
+        my $resp = $self->soap_call(
+            req  => $req,
+            attr => $attr,
+            head => $self->auth,
+            body => $body
+        );
+        die $self->Error unless $resp;
+
+        # Convert authToken into value that can be passed to zimbra requests
+        # and cache for all future requests
+        $self->{_zimbra_delegateauth}{$account} = SOAP::Header->name(
+            "context" => \SOAP::Header->value(
+                SOAP::Header->name(
+                    "authToken" => $resp->valueof('//authToken')
+                ),
+                SOAP::Header->name( "account" => $account )
+                  ->attr( { by => "name" } ),
+            )
+        )->attr( { xmlns => "urn:zimbra" } );
+    }
+    return $self->{_zimbra_delegateauth}{$account};
+}
+
+=head2 reauth(auth)
+
+Must pass either the auth value or delegateauth value that you want to reauthenticate.
+
+This shouldn't ever need to be called directly soap_call should detect when a
+token is no longer valid and automatically attempt to generate a new one
+using this method.
+
+  $za->reauth($self->auth);                         # re-auth admin
+  $za->reauth($self->delegateauth("test@test.com")) # re-auth "test@test.com"
+
+=cut
+
+sub reauth {
+    my ( $self, $auth ) = @_;
+    if ($auth == $self->{_zimbra_auth}) {
+        delete($self->{_zimbra_auth});
+        return $self->auth;
+    } elsif (exists($self->{_zimbra_delegateauth})) {
+        foreach my $account (keys %{$self->{_zimbra_delegateauth}}) {
+            if ($auth == $self->{_zimbra_delegateauth}{$account}) {
+                delete($self->{_zimbra_delegateauth}{$account});
+                return $self->delegateauth($account);
+            }
+        }
+    }
+}
+
+sub getaccount {
+    my ( $self, $account ) = @_;
+
+    my $req = "GetAccountRequest";
+    my $attr = { "xmlns" => "urn:zimbraAdmin" };
+    my $body =
+      SOAP::Data->name( account => $account )->type("string")
+      ->attr( { by => "name" } );
+
+    return $self->soap_call(
+        req  => $req,
+        attr => $attr,
+        head => $self->auth,
+        body => $body
+    );
+}
+
+sub getaccountid {
+    my ( $self, $value ) = @_;
+
+    if ( $value =~ /\@/ ) {  # probably an account name get SOAP::SOM to find id
+        $value = $self->getaccount($value);
+    }
+    if ( ref($value) eq "SOAP::SOM" ) {
+        $value = $value->dataof('//account')->attr->{id};
+    }
+
+    return $value;
+}
+
+sub modifyaccount {
+    my ( $self, $id, $data ) = @_;
+
+    #my $resp = $self->getaccount($account);
+
+    my @attrs;
+    foreach my $a ( keys %$data ) {
+        push( @attrs,
+            SOAP::Data->name( a => $data->{$a} )->type("string")
+              ->attr( { n => $a } ) );
+    }
+
+    my $req  = "ModifyAccountRequest";
+    my $attr = {
+        "xmlns" => "urn:zimbraAdmin",
+        "id"    => $id
+    };
+
+    return $self->soap_call(
+        req  => $req,
+        attr => $attr,
+        head => $self->auth,
+        body => \@attrs
+    );
+}
+
+sub deleteaccount {
+    my ( $self, $acct ) = @_;
+
+    # Do this to all methods that need $id? This works as expected for
+    # email address, id or SOAP::SOM result from getaccount
+    my $id = $self->getaccountid($acct);
+
+    my $req  = "DeleteAccountRequest";
+    my $attr = { "xmlns" => "urn:zimbraAdmin" };
+    my $body = SOAP::Data->name( id => $id )->type("string");
+
+    return $self->soap_call(
+        req  => $req,
+        attr => $attr,
+        head => $self->auth,
+        body => $body
+    );
+}
+
+sub searchdirectory {
+    my ( $self, %args ) = @_;
+
+	my $req = "SearchDirectoryRequest";
+    my $attr = {
+		"xmlns" => "urn:zimbraAdmin",
+		"types" => "accounts",
+		"query" => $args{query},
+		'attrs' => "$args{attrs}"
+	};
+	my $body = SOAP::Data->type( "xml" => "" );
+
+	return $self->soap_call(
+        req  => $req,
+        attr => $attr,
+        head => $self->auth,
+        body => $body
+    );
+}
+
+
+1;


### PR DESCRIPTION
This script will go through Zimbra's Internal LDAP and look for any account whose last login is greater than specified days (default is 97 days). and modify their account to 'pending' status.
You can pass 'last_login_days' as input parameter to this script.
Also you can pass 'new_status' parameter which will be considered to update user's account status else default would be 'locked' status.
make sure you have right configuration in config.json