### PR TITLE
Mention LDAP server in error messages

### DIFF
--- a/src/libexec/zmreplchk
+++ b/src/libexec/zmreplchk
@@ -60,7 +60,7 @@ foreach my $master (@masters) {
                  ) or die "start_tls: $@";
         if($mesgp->code) {
           $mstatus{$master}[0]=3;
-          $mstatus{$master}[1]="Could not execute StartTLS";
+          $mstatus{$master}[1]="Could not execute StartTLS ($master)";
         }
       }
     }
@@ -71,7 +71,7 @@ foreach my $master (@masters) {
     next;
   }
   $mesgp=$ldapp->bind("cn=config", password => $ldap_pass);
-  $mesgp->code && die "Unable to bind to master: Please set ldap_master_root_password\n";
+  $mesgp->code && die "Unable to bind to master ($master): " . (($ldap_pass) ? $mesgp->error : "Please set ldap_master_root_password") . "\n";
  
   $mesgp = $ldapp->search(
              base    =>  'cn=config',
@@ -102,7 +102,7 @@ foreach my $master (@masters) {
   
   if (!@csns) {
     $mstatus{$master}[0]=5;
-    $mstatus{$master}[1]="Not a replicated master\n";
+    $mstatus{$master}[1]="Not a replicated master ($master)\n";
   }
   $mstatus{$master}[0]=0;
   $mstatus{$master}[1]="CSNs Retrieved";


### PR DESCRIPTION
Always output name of LDAP server in error messages, include LDAP error string when unable to bind (helpful in case `$ldap_pass` at random LDAP master in a MMR setup is simply wrong)