### PR TITLE
Add "delaycompress" for Nginx logs

### DIFF
--- a/conf/zmlogrotate
+++ b/conf/zmlogrotate
@@ -114,6 +114,7 @@
     endscript
     rotate 7
     compress
+    delaycompress
     #su zimbra zimbra
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.zimbra.com/show_bug.cgi?id=106800 (Logrotate spews `gzip: stdin: file size changed while zipping`)