### PR TITLE
zmqstat: fix for partial output and crash caused by undefined initial state of a variable

### DIFF
--- a/src/libexec/zmqstat
+++ b/src/libexec/zmqstat
@@ -101,7 +101,7 @@ sub processQ {
 		#print STDERR "Processing file $_\n";
 		my $fh = new IO::File ($_, "r") || return;
 		my ($rec, $len, $data) = get_record($fh);
-		$qf{TO} = ();
+		$qf{TO} = [];
 		if ($rec eq "C") { # Size
 			($qf{SIZE}) = ($data =~ m/\s*(\d+)\s*\d+\s*\d+/);
 		} 


### PR DESCRIPTION
The variable which is supposed to hold the "todo" recipients from the queue file is not initialized as an array reference.
Therefore, in peculiar cases where the record is missing in the queue file, zmqstat blows up halfway when trying to dereference as an array  something which is undefined.
Initializing it as an empty array reference at the beginning prevents that.

This sort of situation happens, for instance, if a queue object which already delivered to the intended recipients is move to the hold queue after the successful delivery but before being removed from the queue.

Calling zmqstat on the hold queue with `/opt/zimbra/libexec/zmqstat hold` outputs the summaries for the e-mails in the hold queue up to the first problematic one, when zmqstat blows up.

An example from the mailbox log
```
2018-09-27 18:50:15,852 ERROR [{RemoteManager: server1.domain.tld->zimbra@server2.domain.tld:22}-zmqstat hold] [] rmgmt - error scanning com.zimbra.cs.rmgmt.RemoteMailQueue$QueueHandler@1cb7431b: Can't use an undefined value as an ARRAY reference at /opt/zimbra/libexec/zmqstat line 159
.

```

In the queue monitoring interface in the admin console the administrator will see displayed only a portion of the objects in the hold queue despite seeing a higher count of objects for the hold queue.