### PR TITLE
Support for the long format for queue IDs in Postfix

### DIFF
--- a/src/libexec/zmlogprocess
+++ b/src/libexec/zmlogprocess
@@ -38,6 +38,21 @@ my $state_file = "/opt/zimbra/log/zmlogprocess.state";
 $logger_directory = getLocalConfig("logger_data_directory");
 $log_file = '/var/log/zimbra.log';
 
+
+# Regexes for Postfix Queue IDs
+
+# Short Format character: ASCII uppercase A-F range plus ASCII digits
+my $SF_QID_CHAR = qr{[A-F0-9]};
+
+# Long Format time portion character:  ASCII digits and ASCII uppercase/lowercase consonants
+my $LF_QID_TIME_CHAR  = qr{[0-9BCDFGHJKLMNPQRSTVWXYZ]}i;
+
+# Long Format inode number portion character: ASCII digits and ASCII uppercase/lowercase consonants minus "z"
+my $LF_QID_INODE_CHAR = qr{[0-9BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxy]};
+
+my $REGEX_POSTFIX_QID = qr{(?:${SF_QID_CHAR}{6,}+|${LF_QID_TIME_CHAR}{10,}z${LF_QID_INODE_CHAR}++)};
+
+
 sub gethostmap() {
     my $dbh = DBI->connect(
             "dbi:SQLite:dbname=$logger_directory/logger.sqlitedb", "", "");
@@ -246,7 +261,7 @@ sub run() {
                 }
             }
         } elsif ($app =~ /^postfix/o) {
-            if ($msg =~ /^([A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+):/) {
+            if ($msg =~ /^(${REGEX_POSTFIX_QID}):/o) {
                 my $qid = $1;
             	counter_qid_add(\%host_qid_data, $host, $qid, $log_date);
                 counter_increment(\%host_data, $host, 'mta_count')

--- a/src/libexec/zmlogprocess
+++ b/src/libexec/zmlogprocess
@@ -246,7 +246,7 @@ sub run() {
                 }
             }
         } elsif ($app =~ /^postfix/o) {
-            if ($msg =~ /^([A-F0-9]+):/) {
+            if ($msg =~ /^([A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+):/) {
                 my $qid = $1;
             	counter_qid_add(\%host_qid_data, $host, $qid, $log_date);
                 counter_increment(\%host_data, $host, 'mta_count')

--- a/src/libexec/zmmsgtrace
+++ b/src/libexec/zmmsgtrace
@@ -135,6 +135,21 @@ my $LOGFILE = "/var/log/zimbra.log";
 my $VERSION = "1.05";
 my $Prog    = basename($0);
 
+
+# Regexes for Postfix Queue IDs
+
+# Short Format character: ASCII uppercase A-F range plus ASCII digits
+my $SF_QID_CHAR = qr{[A-F0-9]};
+
+# Long Format time portion character:  ASCII digits and ASCII uppercase/lowercase consonants
+my $LF_QID_TIME_CHAR  = qr{[0-9BCDFGHJKLMNPQRSTVWXYZ]}i;
+
+# Long Format inode number portion character: ASCII digits and ASCII uppercase/lowercase consonants minus "z"
+my $LF_QID_INODE_CHAR = qr{[0-9BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxy]};
+
+my $REGEX_POSTFIX_QID = qr{(?:${SF_QID_CHAR}{6,}+|${LF_QID_TIME_CHAR}{10,}z${LF_QID_INODE_CHAR}++)};
+
+
 {
     my %mon = (
         Jan => '01',
@@ -356,7 +371,7 @@ sub doit {
             # ...: milter-discard: ...: ...; from=<> to=<> proto=... helo=<h>
             # postfix messages like /^$qid: key=value, .../
             if (    $ent{app} =~ /^postfix/
-                and $ent{msg} =~ /^([A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+|NOQUEUE): (.*)/ )
+                and $ent{msg} =~ /^(${REGEX_POSTFIX_QID}|NOQUEUE): (.*)/o )
             {
                 my ( $qid, $msg ) = ( $1, $2 );
                 my $key  = $qid . ":" . $ent{host};

--- a/src/libexec/zmmsgtrace
+++ b/src/libexec/zmmsgtrace
@@ -356,7 +356,7 @@ sub doit {
             # ...: milter-discard: ...: ...; from=<> to=<> proto=... helo=<h>
             # postfix messages like /^$qid: key=value, .../
             if (    $ent{app} =~ /^postfix/
-                and $ent{msg} =~ /^([A-F0-9]+|NOQUEUE): (.*)/ )
+                and $ent{msg} =~ /^([A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+|NOQUEUE): (.*)/ )
             {
                 my ( $qid, $msg ) = ( $1, $2 );
                 my $key  = $qid . ":" . $ent{host};

--- a/src/libexec/zmqstat
+++ b/src/libexec/zmqstat
@@ -88,7 +88,7 @@ sub getHashPath {
 
 sub processQ {
 	if (! -f $_ ) {return;}
-	if (! m{(^|/)[A-F0-9]{6,}$} ) { return; }
+	if (! m{(?:^|/)(?:[A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+)$} ) { return; }
 	$qfiles++;
 	my ($cdir) = ($File::Find::dir =~ m|([^/]*)|);
 	#print STDERR "Processing $cdir - $_\n";

--- a/src/libexec/zmqstat
+++ b/src/libexec/zmqstat
@@ -79,6 +79,20 @@ sub get_record {  # Borrowed from qshape
 sub getHashPath {
 	my $fn = shift;
 	my $p = "";
+	if ( (my $index = rindex($fn, "z") ) != -1 ) {
+		my @charlist = (
+			0..9,
+			"B".."D","F".."H","J".."N","P".."T","V".."Z",
+			"b".."d","f".."h","j".."n","p".."t","v".."z"
+		);
+		my %map = map { ( $charlist[$_], $_) } 0 .. $#charlist;
+		my @chars = reverse split //, substr($fn, $index-4, 4);
+		$fn = 0;
+		for (my $i=0; $i <= 4; $i++ ) {
+			$fn += $map{ $chars[$i] } * 52 ** $i;
+		}
+		$fn = sprintf("%05X", $fn);
+	}
 	for (my $i = 0; $i < $hash_queue_depth; $i++) {
 		$p .= substr($fn, $i, 1);
 		$p .="/";

--- a/src/libexec/zmqstat
+++ b/src/libexec/zmqstat
@@ -35,6 +35,29 @@ my $queue_directory;
 
 my $qfiles = 0;
 
+# Map for Long Format Queue IDs
+my $ALPHACHARS = "BCDFGHJKLMNPQRSTVWXYZ";
+
+# Map of 52 characters for Long Format Queue IDs:
+# ASCII digits and Lower/Upper Case ASCII letters without AEIOU/aeiou
+my @CHARLIST = ( 0..9, split( //, $ALPHACHARS . lc($ALPHACHARS) ) );
+my %CHARMAP = map { ( $CHARLIST[$_], $_) } 0 .. $#CHARLIST;
+
+
+# Regexes for Postfix Queue IDs
+
+# Short Format character: ASCII uppercase A-F range plus ASCII digits
+my $SF_QID_CHAR = qr{[A-F0-9]};
+
+# Long Format time portion character:  ASCII digits and ASCII uppercase/lowercase consonants
+my $LF_QID_TIME_CHAR  = qr{[0-9BCDFGHJKLMNPQRSTVWXYZ]}i;
+
+# Long Format inode number portion character: ASCII digits and ASCII uppercase/lowercase consonants minus "z"
+my $LF_QID_INODE_CHAR = qr{[0-9BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxy]};
+
+my $REGEX_POSTFIX_QID = qr{(?:${SF_QID_CHAR}{6,}+|${LF_QID_TIME_CHAR}{10,}z${LF_QID_INODE_CHAR}++)};
+
+
 sub getLocalConfig {
 	my $key = shift;
 	if (defined ($ENV{zmsetvars})) {
@@ -80,16 +103,10 @@ sub getHashPath {
 	my $fn = shift;
 	my $p = "";
 	if ( (my $index = rindex($fn, "z") ) != -1 ) {
-		my @charlist = (
-			0..9,
-			"B".."D","F".."H","J".."N","P".."T","V".."Z",
-			"b".."d","f".."h","j".."n","p".."t","v".."z"
-		);
-		my %map = map { ( $charlist[$_], $_) } 0 .. $#charlist;
-		my @chars = reverse split //, substr($fn, $index-4, 4);
+		my @chars = reverse( split( //, substr($fn, $index-4, 4) ) );
 		$fn = 0;
 		for (my $i=0; $i <= 4; $i++ ) {
-			$fn += $map{ $chars[$i] } * 52 ** $i;
+			$fn += $CHARMAP{ $chars[$i] } * 52 ** $i;
 		}
 		$fn = sprintf("%05X", $fn);
 	}
@@ -102,7 +119,7 @@ sub getHashPath {
 
 sub processQ {
 	if (! -f $_ ) {return;}
-	if (! m{(?:^|/)(?:[A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+)$} ) { return; }
+	if (! m{(?:^|/)${REGEX_POSTFIX_QID}$}o ) { return; }
 	$qfiles++;
 	my ($cdir) = ($File::Find::dir =~ m|([^/]*)|);
 	#print STDERR "Processing $cdir - $_\n";

--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -59,7 +59,21 @@ my %SIMPLE_COMMANDS = (
    "downloadcsr"      => "cat /opt/zimbra/ssl/zimbra/commercial/commercial.csr"
 );
 
-my $REGEX_POSTFIX_QID = qr{(?:[A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+)};
+
+# Regexes for Postfix Queue IDs
+
+# Short Format character: ASCII uppercase A-F range plus ASCII digits
+my $SF_QID_CHAR = qr{[A-F0-9]};
+
+# Long Format time portion character:  ASCII digits and ASCII uppercase/lowercase consonants
+my $LF_QID_TIME_CHAR  = qr{[0-9BCDFGHJKLMNPQRSTVWXYZ]}i;
+
+# Long Format inode number portion character: ASCII digits and ASCII uppercase/lowercase consonants minus "z"
+my $LF_QID_INODE_CHAR = qr{[0-9BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxy]};
+
+my $REGEX_POSTFIX_QID = qr{(?:${SF_QID_CHAR}{6,}+|${LF_QID_TIME_CHAR}{10,}z${LF_QID_INODE_CHAR}++)};
+
+
 
 my %REGEX_CHECKED_COMMANDS = (
   "zmqaction" => {

--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -59,9 +59,11 @@ my %SIMPLE_COMMANDS = (
    "downloadcsr"      => "cat /opt/zimbra/ssl/zimbra/commercial/commercial.csr"
 );
 
+my $REGEX_POSTFIX_QID = qr{(?:[A-F0-9]{6,}|[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]{10}z[0-9B-DF-HJ-NP-TV-Zb-df-hj-np-tv-y]+)};
+
 my %REGEX_CHECKED_COMMANDS = (
   "zmqaction" => {
-    regex => '(hold|release|requeue|delete)\s+(incoming|deferred|corrupt|active|maildrop|hold)\s+[A-FL0-9,]+', # A-F allows hex, L allows ALL
+    regex => qr{(hold|release|requeue|delete)\s+(incoming|deferred|corrupt|active|maildrop|hold)\s+(?:(?:${REGEX_POSTFIX_QID},)*+${REGEX_POSTFIX_QID}|ALL)},
     program => "/opt/zimbra/libexec/zmqaction"},
   "zmbackupldap" => {
     regex => '[a-zA-Z0-9\\/\\.\\-_:@ ]*',

--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -74,7 +74,6 @@ my $LF_QID_INODE_CHAR = qr{[0-9BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxy]};
 my $REGEX_POSTFIX_QID = qr{(?:${SF_QID_CHAR}{6,}+|${LF_QID_TIME_CHAR}{10,}z${LF_QID_INODE_CHAR}++)};
 
 
-
 my %REGEX_CHECKED_COMMANDS = (
   "zmqaction" => {
     regex => qr{(hold|release|requeue|delete)\s+(incoming|deferred|corrupt|active|maildrop|hold)\s+(?:(?:${REGEX_POSTFIX_QID},)*+${REGEX_POSTFIX_QID}|ALL)},


### PR DESCRIPTION
As detailed [here](http://www.postfix.org/postconf.5.html#enable_long_queue_ids) and [here](http://www.postfix.org/announcements/postfix-2.9.0.html) a few years ago a new, longer and, more importantly, non repeating queue id format was introduced by Postfix.
That brings much simpler log analysis avoiding queue ID reuse, something which happens even over short intervals of time.
The commits alter regexes across a few commands interacting with logs and the Postfix queue in order to account for the new format and, in the case of zmqstat, also add the algorithm to extract the folder hierarchy in which the queue file is placed from the ID, algorithm which is different from the one used for the short format.

In order for actions on queue files using the long format to work from the admin console the PR https://github.com/Zimbra/zm-mailbox/pull/794 is necessary.