### PR TITLE
ZCS-7412:zmqstat: added support for pointer and terminator records in the postfix

### DIFF
--- a/src/libexec/zmqstat
+++ b/src/libexec/zmqstat
@@ -133,6 +133,12 @@ sub processQ {
                                 } else {
                                         $qf{TIME} = $data;
                                 }
+                        } elsif ($rec eq "p") {
+                                if ($data > 0) {
+                                        seek($fh,$data,0) or return();
+                                }
+                        } elsif ($rec eq "E") {
+                                last;
                         } 
 		}
 		$fh->close();


### PR DESCRIPTION
queue file

zmqstat at present does not follow pointer records used by postfix to
jump around the queue file when inserting headers inside the original
message.
That can lead to incorrect processing of the queue file and to the output
of zmqstat being filled with random data, which in turn breaks things up
the calling chain to the admin console.

This commit introduces support for the pointer and terminator records
for correct processing of the queue file.

Sample output of postcat -v -o  displaying file offsets on such a queue file
```
     4890 pointer_record:               0
     4907 *** MESSAGE CONTENTS /opt/zimbra/data/postfix/spool/hold/2283D163C2F ***
     4909 regular_text: Received: from localhost (localhost [127.0.0.1])
     4959 regular_text:         by out2.cloudserver.tld (Postfix) with ESMTP id 2283D163C2F;
     5021 regular_text:         Sat, 30 Jun 2018 14:30:56 +0200 (CEST)
     5062 pointer_record:         4753954
  4753954 regular_text: DKIM-Filter: OpenDKIM Filter v2.9.2 out2.cloudserver.tld 2283D163C2F
  4754023 pointer_record:         4752907
  4752907 regular_text: DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=testdm.domain.tld;
  4752982 regular_text:         s=06412A02-8CB7-11E7-8E5E-4F12C731C49F; t=1530361856;
  4753038 regular_text:         bh=8d6PfHDesgAG3pGLn/CcT1mWAR08VMZWUF8/pAQDppE=;
  4753089 regular_text:         h=Date:From:Reply-To:Message-ID:Subject:MIME-Version:Content-Type;
  4753158 regular_text:         b=0L8Pb/rYu0WPPqqezz8IilTKruaFPU7bV/7kd05KOte6X10ii2QtdB9YBwrKl9jVs
  4753228 regular_text:          FVWgSFFaYCSEpUeNebrjppKGr40YJKJ7WSf1LheH4vAl/p12I+t/vxdWC6ar0AccCF
  4753298 regular_text:          mh6+JzlAip10ycPFhsHlcp5yV8G/7ZXV4H4/rLd/2U9Jd9JIlrnJY25RabsnGrJEs+
  4753368 regular_text:          OLSDnoN1oSxAWY87o0jKPd/knn7PWArpveUh5ilCuiZq3E8ZNrlgQULFEwLbS/rtZ1
  4753438 regular_text:          7q5R1pv1hQhIf3hqkGEnCwX+QRwZu1QMf0hOoMjPN7Ghr2agF6efiHD/Xw09/4HUAU
  4753508 regular_text:          9Gh/qrFWMc25JzAGg8nrDDGzwHWc5qyS/TNwcPgnGXHUH4Dq+Sy6s+g6J3j4YNrsJp
  4753578 regular_text:          iNmLgdLoCYuyMSfgueCOegX6MmKPYAHhW1Apw563k1M3yzeg8dtQ1IKAq+ZeYTp0Ca
  4753648 regular_text:          vvoz7C6N9RFvjLbLqK/A/1jFrRLib5D34JD3eJWu88CyBWoItkJegpNF1QVim4J2xq
  4753718 regular_text:          cnmdl/TZKJJhmbOATP/mxMYrtEAwC/fcAX38E5VYgMzko3sZ/xuz22vodrSg1KOPmm
  4753788 regular_text:          Ly5yds8gjsWhVgKdE5hB3pBuCSt1A5iKz282upW+xLw1HaqLZx4lS4G4lc47+1tLfQ
  4753858 regular_text:          52uO7bNd5LWsjghxyAGfc9ZQ=
  4753887 regular_text: Received: from out2.cloudserver.tld ([127.0.0.1])
  4753937 pointer_record:            5112
     5112 regular_text:         by localhost (out2.cloudserver.tld [127.0.0.1]) (amavisd-new, port 10026)
     5187 regular_text:         with ESMTP id MeVTFYPW9OIv; Sat, 30 Jun 2018 14:30:54 +0200 (CEST)
```
Output of the unpatched zmqstat for the object:
```
id=2283D163C2F
time=FjAZsRE3kx9KOw5O5aRunyc32NL3kxmDzWB5YCACmwWYNdMuZ6AQvm9ScdlOlZN4COD8K614jxxbiLsGuyJKfY4I/cot74gN72v1wVBNL
size=4747962
from=WpTWb3j0LfwSBESpN0WvaIltAC5K4XPg8oKOV/cpH5qFCFTS8fFRrP+yq4147K62nQNaT1S4KNLIjT5T9ONbCZ/gvTERDi2t+ZoTf0MY1Rs2HdJSBH3ZcQe
addr=127.0.0.1
host=localhost
filter=EK1Ljf5NUrd37BbOGfBuSFYGKOCMACEEUDHwRkUSeOHHz8Nf/jl89NfqHBLF34hx5LHwfJm+IyNNLDW5UKZiNg+1qPPjD81N9EN4
to=OByTzX8Jv8HF4saQaMO/j9sNLIl5vNPYYUnAQkht++/z0xz8NavjYdP777/HBfmU4gHx
```
Correct output:
```
id=2283D163C2F
time=1530361856
size=4747962
from=recipient@testdm.domain.tld
received=10.1.1.1
addr=127.0.0.1
host=localhost
filter=smtp-amavis:[127.0.0.1]:10032
to=
```