### PR TITLE
ZCS-6714 Modifying java classpath to support JDK 11

### DIFF
--- a/src/bin/zmjava
+++ b/src/bin/zmjava
@@ -23,8 +23,7 @@ zmsetvars -f
 if [ -d ${zimbra_java_home}/jre ]; then
     JRE_EXT_DIR=${zimbra_java_home}/jre/lib/ext
 else
-    #JRE_EXT_DIR=/System/Library/Frameworks/JavaVM.framework/Versions/1.5/Home/lib/ext
-    JRE_EXT_DIR=${zimbra_java_home}/lib/ext
+		JRE_EXT_DIR=${zimbra_java_home}/lib/ext
 fi
 
 if [ -f ".hotspot_compiler" ]; then
@@ -36,10 +35,10 @@ CYGWIN*) PATHSEP=";";;
 esac
 
 ZIMBRA_EXTENSIONS="backup clamscanner network zimbra-license zimbrahsm zimbrasync twofactorauth com_zimbra_ssdb_ephemeral_store"
-ZIMBRA_EXT_DIR="/opt/zimbra/lib/ext-common"
+ZIMBRA_EXT_DIR="/opt/zimbra/lib/ext-common/*"
 for i in $ZIMBRA_EXTENSIONS; do
   if [ -d "/opt/zimbra/lib/ext/$i" ]; then
-   ZIMBRA_EXT_DIR="${ZIMBRA_EXT_DIR}${PATHSEP}/opt/zimbra/lib/ext/$i"
+   ZIMBRA_EXT_DIR="${ZIMBRA_EXT_DIR}${PATHSEP}/opt/zimbra/lib/ext/$i/*"
   fi
 done
 
@@ -57,5 +56,5 @@ exec ${zimbra_java_home}/bin/java ${java_options} \
      -client ${zimbra_zmjava_options} \
      -Dzimbra.home=/opt/zimbra \
      -Djava.library.path=${zimbra_zmjava_java_library_path} \
-     -Djava.ext.dirs=${zimbra_zmjava_java_ext_dirs} \
+     -classpath "${zimbra_zmjava_java_ext_dirs}:/opt/zimbra/lib/jars/*" \
      "$@"


### PR DESCRIPTION
Modified zmjava to include the zimbra ext dirs in classpath

Installed on ZCS with JDK 11 verified ZCS process starts without any issue