### PR TITLE
ZCS-6389 Fixing script path for JDK11

### DIFF
--- a/src/bin/zmjava
+++ b/src/bin/zmjava
@@ -48,8 +48,8 @@ if [ x${zimbra_zmjava_java_library_path} = "x" ]; then
   zimbra_zmjava_java_library_path=/opt/zimbra/lib
 fi
 
-if [ x${zimbra_zmjava_java_ext_dirs} = "x" ]; then
-  zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}${PATHSEP}/opt/zimbra/lib/jars${PATHSEP}${ZIMBRA_EXT_DIR}
+if [ ! -z "${EXT_JAR_PATH}" ]; then
+  zimbra_zmjava_java_ext_dirs=${zimbra_zmjava_java_ext_dirs}${PATHSEP}${EXT_JAR_PATH}
 fi
 
 exec ${zimbra_java_home}/bin/java ${java_options} \

--- a/src/bin/zmlocalconfig
+++ b/src/bin/zmlocalconfig
@@ -55,7 +55,11 @@ ${PATHSEP}${ZMROOT}/lib/jars/httpclient-4.5.2.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/httpcore-4.4.5.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/dom4j-1.5.2.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/log4j-1.2.16.jar\
-${PATHSEP}${ZMROOT}/lib/jars/json.jar
+${PATHSEP}${ZMROOT}/lib/jars/json.jar\
+${PATHSEP}${ZMROOT}/lib/jars/activation-1.1.1.jar\
+${PATHSEP}${ZMROOT}/lib/jars/jaxb-api-2.3.1.jar\
+${PATHSEP}${ZMROOT}/lib/jars/jaxb-impl-2.3.1.jar\
+${PATHSEP}${ZMROOT}/lib/jars/istack-commons-runtime-3.0.8.jar
 
 if [ -f "${ZMROOT}/lib/ext/backup/zimbrabackup.jar" ]; then
     CP="$CP${PATHSEP}${ZMROOT}/lib/ext/backup/zimbrabackup.jar"

--- a/src/libexec/zmcheckversion
+++ b/src/libexec/zmcheckversion
@@ -1,0 +1,21 @@
+#!/bin/bash
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2009, 2013, 2014, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+EXT_JAR_PATH=/opt/zimbra/lib/ext/zimbraadminversioncheck/zimbraadminversioncheck.jar
+export EXT_JAR_PATH
+exec `dirname $0`/../bin/zmjava com.zimbra.cs.versioncheck.VersionCheckUtil "$@"


### PR DESCRIPTION
Fixed ClassNotFound error after Genesis run.
Reran the Genesis test cases and verified they are passing

