### PR TITLE
ZCS-6953:fixing jdk11 classpath issue

### DIFF
--- a/src/bin/zmplayredo
+++ b/src/bin/zmplayredo
@@ -59,16 +59,17 @@ else
     #JRE_EXT_DIR=${zimbra_java_home}/lib/ext
 fi
 
-jardirs=${JRE_EXT_DIR}:/opt/zimbra/mailboxd/lib:/opt/zimbra/mailboxd/common/lib:/opt/zimbra/lib/jars
+jardirs=${JRE_EXT_DIR}:/opt/zimbra/mailboxd/lib/*:/opt/zimbra/mailboxd/common/lib/*:/opt/zimbra/lib/jars/*
 if [ -e /opt/zimbra/lib/ext-common ]; then
-    jardirs=${jardirs}:/opt/zimbra/lib/ext-common
+    jardirs=${jardirs}:/opt/zimbra/lib/ext-common/*
 fi
 for jd in `find /opt/zimbra/lib/ext -type d` ; do
     if [ ${jd} != /opt/zimbra/lib/ext ]; then
-        jardirs="${jardirs}:${jd}"
+        jardirs="${jardirs}:${jd}/*"
     fi
 done
 
+jardirs="${jardirs}:/opt/zimbra/jetty/common/lib/*:/opt/zimbra/jetty/webapps/service/WEB-INF/lib/*"
 #
 # Memory for use by JVM
 #
@@ -102,7 +103,7 @@ ${zimbra_java_home}/bin/java \
     ${xms_xmx_options} ${sanitized_options} \
     -Dzimbra.config=/opt/zimbra/conf/localconfig.xml \
     -Djava.library.path=/opt/zimbra/lib \
-    -Djava.ext.dirs=${jardirs} \
+    -classpath ${jardirs} \
     com.zimbra.cs.redolog.util.PlaybackUtil "$@"
 rc=$?
 rm -f $ropid


### PR DESCRIPTION
**Issue:** zmplayredo was failing in jdk 11 causing **ClassNotFoundException** as jdk11 does not have any ext directories. 

Fix: Removed '-Djava.ext.dirs' argument and replaced it with '-classpath' argument.

Tested genesis run  on zdev-vm016 and it is working as expected.
