### PR TITLE
ZCS-7106:Fix the GC optimisation argumnets

### DIFF
--- a/src/bin/zmmailboxdctl
+++ b/src/bin/zmmailboxdctl
@@ -93,7 +93,7 @@ case "$1" in
       echo -n "Starting mailboxd..."
       sudo /opt/zimbra/libexec/zmmailboxdmgr start \
         -Dfile.encoding=UTF-8 ${mailboxd_java_options} ${spnegoJavaOptions} -Xms${javaXms}m \
-        -Xmx${javaXmx}m -Xmn${javaXmn}m < /dev/null > /dev/null 2>&1
+        -Xmx${javaXmx}m < /dev/null > /dev/null 2>&1
       status=$?
       if [ $status != 0 ]; then
         echo "failed."


### PR DESCRIPTION
issue : Young Gen Size JVM options was added which was somehow affecting garbage collection performance because the ratio of the heap dedicated to the young generation was quite high.

removed Young Gen Size  JVM arguments **-Xmn${javaXmn}m**. This is the summary after 1 hour of load test.

> summary +    699 in 00:00:06 =  119.6/s Avg:  1921 Min:     0 Max:  9828 Err:     0 (0.00%) Active: 0 Started: 200 Finished: 200
summary = 520455 in 01:00:09 =  144.2/s Avg:  1423 Min:     0 Max: 59644 Err:     0 (0.00%)
Tidying up ...    @ Thu Apr 18 09:37:05 EDT 2019 (1555594625855)
... end of run
Performance test ended at :- 04/18/2019 09:37:08

