### PR TITLE
ZBUG-962 Fixing heapdump, thrddump

### DIFF
--- a/src/bin/zmthrdump
+++ b/src/bin/zmthrdump
@@ -61,10 +61,6 @@ usage() if ($opts{'h'});
 
 my $id = getpwuid($<);
 chomp $id;
-if ($id ne "zimbra") {
-    print STDERR "Error: must be run as zimbra user\n";
-    exit (1);
-}
 
 $log_file = $opts{'f'} if (exists $opts{'f'} && defined $opts{'f'});
 usage() if (exists $opts{'f'} && !defined $opts{'f'});

--- a/src/libexec/zmdiaglog
+++ b/src/libexec/zmdiaglog
@@ -121,12 +121,11 @@ sub save_heap_info($$$$) {
 
     $histo_cmd = "$JMAP -histo:live $pid";
     $dump_file = "$destination/heapdump-live.hprof";
-    $dump_cmd  = "$SU '$JMAP -dump:live,file=$dump_file $pid'";
-
+    $dump_cmd  = " '$JMAP -dump:live,file=$dump_file $pid'";
     logmsg "Retrieving JVM $version heap histogram\n";
-    exec_with_timeout( "$SU '$histo_cmd' > heap.histo 2>&1", $timeout );
+    exec_with_timeout( " '$histo_cmd' > heap.histo 2>&1", $timeout );
     logmsg "Saving JVM $version heapdump\n";
-    my $success = exec_with_timeout( "$dump_cmd", $timeout );
+    my $success =  system("bash -c $dump_cmd "); 
     my $dumped = -f "$dump_file";
     $dumped && $success;
 }
@@ -200,7 +199,7 @@ sub get_pid() {
 
 sub invoke_thread_dump($$) {
     my ( $i, $ts ) = @_;
-    system("su zimbra -c '/opt/zimbra/bin/zmthrdump -i' > threaddump.$i.$ts 2>&1");
+    system("bash -c 'cd /opt/zimbra/bin/; ./zmthrdump -i' > threaddump.$i.$ts 2>&1");
 }
 
 sub collect_thread_stats($) {


### PR DESCRIPTION
Fixed the code that generated heapdump and thread dump. These commands need to run now as root user.

Verified that threaddump and headpdump are generated
Verified the files output for zmdiaglog with 8.8.11 version.

