### PR TITLE
ZCS-7180 Bad PID checks

### DIFF
--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -24,8 +24,8 @@ mkdir -p "/opt/zimbra/data/ldap/state/run/"
 source /opt/zimbra/bin/zmshutil || exit 1
 zmsetvars
 
-if [ x$ldap_is_master = "xfalse" ]; then
-    if [ "x$ldap_url" = "x$ldap_master_url" -a "x$1" != "xstop" ]; then
+if [ "x$ldap_is_master" = "xfalse" ]; then
+    if [ "x$ldap_url" = "x$ldap_master_url" ] && [ "x$1" != "xstop" ]; then
         echo "ldap_url and ldap_master_url cannot be the same on an ldap replica"
         exit 1
     fi
@@ -34,7 +34,7 @@ fi
 getpid()
 {
     if [ -f $PIDFILE ]; then
-        PID=`cat $PIDFILE`
+        PID=$(cat $PIDFILE)
     fi
 }
 
@@ -44,12 +44,11 @@ checkrunning()
     if [ "x$PID" = "x" ]; then
         RUNNING=0
     else
-        ps --no-headers -p $PID -o cmd 2>/dev/null |grep slapd >/dev/null 2>&1
-        if [ $? != 0 ]; then
+        if ps --no-headers -p "$PID" -o cmd 2>/dev/null |grep slapd >/dev/null 2>&1 ; then
+            RUNNING=1
+        else
             PID=""
             RUNNING=0
-        else
-            RUNNING=1
         fi
     fi
 }
@@ -72,7 +71,7 @@ checkListening()
 doDebugStart() {
     TIMEOUT=60 # timelimit for command
     sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 -u zimbra -h "${bind_url} ldapi:///" \
-            -F /opt/zimbra/data/ldap/config -d 1 2>&1 | egrep "failed|error" &
+            -F /opt/zimbra/data/ldap/config -d 1 2>&1 | grep -e "failed" -e "error" &
     cmd_pid=$!
     sleep $TIMEOUT | (
         read nothing # wait on sleep to finish
@@ -96,12 +95,12 @@ start()
     # Our ldap url should be the first in the list in localconfig
     bind_url=$ldap_bind_url
     if [ x"$bind_url" = "x" ]; then
-        bind_url=$(echo ${ldap_url} | awk '{print $1}')
+        bind_url=$(echo "${ldap_url}" | awk '{print $1}')
     fi
     for ((i =0; i <= 30; i++)); do
         checkrunning
         if [ $RUNNING = 0 ]; then
-            if (($i % 5 == 0)); then
+            if ((i % 5 == 0)); then
                 sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
                 -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
             fi
@@ -140,18 +139,16 @@ stop()
     echo -n "Killing slapd with pid $PID"
     kill -TERM $PID
     for ((i =0; i < 1500; i++)); do
-        sleep 1
-        kill -0 $PID 2> /dev/null
-        if [ $? != 0 ]; then
+        if ! kill -0 $PID 2> /dev/null; then
             echo " done."
             exit 0
         fi
-        if (($i % 5 == 0)); then
+        if ((i % 5 == 0)); then
             echo -n "."
         fi
+        sleep 1
     done
-    kill -TERM $PID
-    if [ $? = 0 ]; then
+    if kill -TERM $PID; then
         echo " gave up waiting!"
         exit 1
     fi

--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -44,7 +44,7 @@ checkrunning()
     if [ "x$PID" = "x" ]; then
         RUNNING=0
     else
-        kill -0 $PID
+        ps --no-headers -p $PID -o cmd 2>/dev/null |grep slapd >/dev/null 2>&1
         if [ $? != 0 ]; then
             PID=""
             RUNNING=0

--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -85,44 +85,43 @@ doDebugStart() {
     exit 1
 }
 
+
 start()
 {
     checkrunning
-    if [ $RUNNING = 0 ]; then
-        # Our ldap url should be the first in the list in localconfig
-        bind_url=$ldap_bind_url
-        if [ x"$bind_url" = "x" ]; then
-            bind_url=$(echo ${ldap_url} | awk '{print $1}')
-        fi
-        sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
-            -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
-        sleep 5
-        for ((i =0; i < 6; i++)); do
-            checkrunning
-            if [ $RUNNING = 0 ]; then
-                sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
-                    -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
-            else
-                break
-            fi
-            sleep 5
-        done
-        if [ "x$PID" = "x" ]; then
-            echo "Failed to start slapd.  Attempting debug start to determine error."
-            doDebugStart
-        else
-            echo "Started slapd: pid $PID"
-        fi
-    else
+    if [ $RUNNING != 0 ]; then
         echo "slapd already running: pid $PID"
         exit 1
     fi
-    for ((i =0; i < 6; i++)); do
+    # Our ldap url should be the first in the list in localconfig
+    bind_url=$ldap_bind_url
+    if [ x"$bind_url" = "x" ]; then
+        bind_url=$(echo ${ldap_url} | awk '{print $1}')
+    fi
+    for ((i =0; i <= 30; i++)); do
+        checkrunning
+        if [ $RUNNING = 0 ]; then
+            if (($i % 5 == 0)); then
+                sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
+                -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
+            fi
+        else
+            break
+        fi
+        sleep 1
+    done
+    if [ "x$PID" = "x" ]; then
+        echo "Failed to start slapd.  Attempting debug start to determine error."
+        doDebugStart
+    else
+        echo "Started slapd: pid $PID"
+    fi
+    for ((i =0; i < 30; i++)); do
         checkListening
         if [ $LISTENING = 1 ]; then
             break
         fi
-        sleep 5
+        sleep 1
     done
     if [ $LISTENING = 0 ]; then
         echo "Error: Unable to check that slapd is listening to connections"
@@ -133,29 +132,30 @@ start()
 stop()
 {
     checkrunning
+
     if [ $RUNNING = 0 ]; then
         echo "slapd not running"
         exit 0
-    else
-        echo -n "Killing slapd with pid $PID"
-        kill -TERM $PID
-        for ((i =0; i < 300; i++)); do
-            sleep 5
-            kill -0 $PID 2> /dev/null
-            if [ $? != 0 ]; then
-                echo " done."
-                exit 0
-            fi
-            echo -n "."
-        done
-        kill -TERM $PID
-        if [ $? = 0 ]; then
-            echo " gave up waiting!"
-            exit 1
-        else
-            echo " done."
-        fi
     fi
+    echo -n "Killing slapd with pid $PID"
+    kill -TERM $PID
+    for ((i =0; i < 1500; i++)); do
+        sleep 1
+        kill -0 $PID 2> /dev/null
+        if [ $? != 0 ]; then
+            echo " done."
+            exit 0
+        fi
+        if (($i % 5 == 0)); then
+            echo -n "."
+        fi
+    done
+    kill -TERM $PID
+    if [ $? = 0 ]; then
+        echo " gave up waiting!"
+        exit 1
+    fi
+    echo " done."
     exit 0
 }
 

--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # ***** BEGIN LICENSE BLOCK *****
 # Zimbra Collaboration Suite Server
 # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along with this program.
 # If not, see <https://www.gnu.org/licenses/>.
 # ***** END LICENSE BLOCK *****
-# 
+#
 
 PID=""
 PIDFILE="/opt/zimbra/data/ldap/state/run/slapd.pid"
@@ -25,170 +25,167 @@ source /opt/zimbra/bin/zmshutil || exit 1
 zmsetvars
 
 if [ x$ldap_is_master = "xfalse" ]; then
-  if [ "x$ldap_url" = "x$ldap_master_url" -a "x$1" != "xstop" ]; then
-    echo "ldap_url and ldap_master_url cannot be the same on an ldap replica"
-    exit 1
-  fi
+    if [ "x$ldap_url" = "x$ldap_master_url" -a "x$1" != "xstop" ]; then
+        echo "ldap_url and ldap_master_url cannot be the same on an ldap replica"
+        exit 1
+    fi
 fi
 
 getpid()
 {
-	if [ -f $PIDFILE ]; then
-		PID=`cat $PIDFILE`
-	fi
+    if [ -f $PIDFILE ]; then
+        PID=`cat $PIDFILE`
+    fi
 }
 
 checkrunning()
 {
-	getpid
-	if [ "x$PID" = "x" ]; then
-		RUNNING=0
-	else
-		kill -0 $PID
-		if [ $? != 0 ]; then
-			PID=""
-			RUNNING=0
-		else
-			RUNNING=1
-		fi
-	fi
+    getpid
+    if [ "x$PID" = "x" ]; then
+        RUNNING=0
+    else
+        kill -0 $PID
+        if [ $? != 0 ]; then
+            PID=""
+            RUNNING=0
+        else
+            RUNNING=1
+        fi
+    fi
 }
 
 checkListening()
 {
-  SEARCHTIMEOUT=30 #timelimit for ldapsearch
-  if [ x"$ldap_common_require_tls" = "x0" ]; then
-    /opt/zimbra/common/bin/ldapsearch -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
-  else
-    /opt/zimbra/common/bin/ldapsearch -ZZ -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
-  fi
-  if [ $? -ne 0 ]; then
-    LISTENING=0
-  else
-    LISTENING=1
-  fi
-
+    SEARCHTIMEOUT=30 #timelimit for ldapsearch
+    if [ x"$ldap_common_require_tls" = "x0" ]; then
+        /opt/zimbra/common/bin/ldapsearch -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
+    else
+        /opt/zimbra/common/bin/ldapsearch -ZZ -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
+    fi
+    if [ $? -ne 0 ]; then
+        LISTENING=0
+    else
+        LISTENING=1
+    fi
 }
 
 doDebugStart() {
-  TIMEOUT=60 # timelimit for command
-	sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 -u zimbra -h "${bind_url} ldapi:///" \
-			-F /opt/zimbra/data/ldap/config -d 1 2>&1 | egrep "failed|error" &
-  cmd_pid=$!
-  sleep $TIMEOUT | (
-    read nothing # wait on sleep to finish
-    kill $cmd_pid 2>/dev/null; # otherwise abort the command!
-  ) &
-  sleep_pid=$!
-  wait $cmd_pid
-  kill -ALRM $sleep_pid 2>/dev/null # kill sleep if still running
-	echo ""
-	exit 1
+    TIMEOUT=60 # timelimit for command
+    sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 -u zimbra -h "${bind_url} ldapi:///" \
+            -F /opt/zimbra/data/ldap/config -d 1 2>&1 | egrep "failed|error" &
+    cmd_pid=$!
+    sleep $TIMEOUT | (
+        read nothing # wait on sleep to finish
+        kill $cmd_pid 2>/dev/null; # otherwise abort the command!
+    ) &
+    sleep_pid=$!
+    wait $cmd_pid
+    kill -ALRM $sleep_pid 2>/dev/null # kill sleep if still running
+    echo ""
+    exit 1
 }
-
 
 start()
 {
-   checkrunning
-   if [ $RUNNING = 0 ]; then
-    # Our ldap url should be the first in the list in localconfig
-    bind_url=$ldap_bind_url
-    if [ x"$bind_url" = "x" ]; then
-		  bind_url=$(echo ${ldap_url} | awk '{print $1}')
+    checkrunning
+    if [ $RUNNING = 0 ]; then
+        # Our ldap url should be the first in the list in localconfig
+        bind_url=$ldap_bind_url
+        if [ x"$bind_url" = "x" ]; then
+            bind_url=$(echo ${ldap_url} | awk '{print $1}')
+        fi
+        sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
+            -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
+        sleep 5
+        for ((i =0; i < 6; i++)); do
+            checkrunning
+            if [ $RUNNING = 0 ]; then
+                sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
+                    -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
+            else
+                break
+            fi
+            sleep 5
+        done
+        if [ "x$PID" = "x" ]; then
+            echo "Failed to start slapd.  Attempting debug start to determine error."
+            doDebugStart
+        else
+            echo "Started slapd: pid $PID"
+        fi
+    else
+        echo "slapd already running: pid $PID"
+        exit 1
     fi
-	sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
-      -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
-    sleep 5
     for ((i =0; i < 6; i++)); do
-      checkrunning
-      if [ $RUNNING = 0 ]; then
-	    sudo /opt/zimbra/libexec/zmslapd -l LOCAL0 \
-          -u zimbra -h "${bind_url} ldapi:///" -F /opt/zimbra/data/ldap/config
-      else 
-        break
-      fi
-      sleep 5
-    done
-		if [ "x$PID" = "x" ]; then
-      echo "Failed to start slapd.  Attempting debug start to determine error."
-      doDebugStart
-		else
-			echo "Started slapd: pid $PID"
-		fi
-	else
-		echo "slapd already running: pid $PID"
-		exit 1
-	fi
-    for ((i =0; i < 6; i++)); do
-      checkListening
-      if [ $LISTENING = 1 ]; then
-        break
-      fi
-      sleep 5
+        checkListening
+        if [ $LISTENING = 1 ]; then
+            break
+        fi
+        sleep 5
     done
     if [ $LISTENING = 0 ]; then
-      echo "Error: Unable to check that slapd is listening to connections"
-      exit 1
+        echo "Error: Unable to check that slapd is listening to connections"
+        exit 1
     fi
 }
 
 stop()
 {
-	checkrunning
-  
-	if [ $RUNNING = 0 ]; then
-		echo "slapd not running"
-		exit 0
-	else
-    echo -n "Killing slapd with pid $PID"
-		kill -TERM $PID
-    for ((i =0; i < 300; i++)); do
-      sleep 5
-      kill -0 $PID 2> /dev/null
-      if [ $? != 0 ]; then
-        echo " done."
+    checkrunning
+    if [ $RUNNING = 0 ]; then
+        echo "slapd not running"
         exit 0
-      fi
-      echo -n "."
-    done
-    kill -TERM $PID
-    if [ $? = 0 ]; then
-      echo " gave up waiting!"
-      exit 1
-    else 
-      echo " done."
+    else
+        echo -n "Killing slapd with pid $PID"
+        kill -TERM $PID
+        for ((i =0; i < 300; i++)); do
+            sleep 5
+            kill -0 $PID 2> /dev/null
+            if [ $? != 0 ]; then
+                echo " done."
+                exit 0
+            fi
+            echo -n "."
+        done
+        kill -TERM $PID
+        if [ $? = 0 ]; then
+            echo " gave up waiting!"
+            exit 1
+        else
+            echo " done."
+        fi
     fi
-	fi
-  exit 0
+    exit 0
 }
 
 status()
 {
-	checkrunning
-	if [ $RUNNING = 0 ]; then
-		exit 1
-	else
-		echo "slapd running pid: $PID"
-		exit 0
-	fi
+    checkrunning
+    if [ $RUNNING = 0 ]; then
+        exit 1
+    else
+        echo "slapd running pid: $PID"
+        exit 0
+    fi
 }
 
-case "$1" in 
-	restart)
-		$0 stop
-		$0 start
-		;;
-	start)
-		start
-		;;
-	stop)
-		stop
-		;;
-	status)
-		status
-		;;
-	*)
-		echo "Usage: $0 start|stop|status"
-		exit 1
-		;;
+case "$1" in
+    restart)
+        $0 stop
+        $0 start
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    *)
+        echo "Usage: $0 start|stop|status"
+        exit 1
+        ;;
 esac

--- a/src/bin/zmapachectl
+++ b/src/bin/zmapachectl
@@ -82,8 +82,7 @@ case "$1" in
       echo "apache is not running."
       exit 1
     fi
-		kill -0 $pid
-    if [ $? = 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null |grep httpd >/dev/null 2>&1; then
       echo "apache is running."
       exit 0
     else 

--- a/src/bin/zmclamdctl
+++ b/src/bin/zmclamdctl
@@ -50,13 +50,12 @@ checkrunning() {
   if [ "x$cpid" = "x" ]; then
     running=0
   else
-    kill -0 $cpid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $cpid -o cmd 2>/dev/null | grep clamd >/dev/null 2>&1; then
+      running=1
+    else
       rm $pidfile
       cpid=""
       running=0
-    else
-      running=1
     fi
   fi
 }

--- a/src/bin/zmfreshclamctl
+++ b/src/bin/zmfreshclamctl
@@ -48,13 +48,12 @@ checkrunning() {
   if [ "x$fpid" = "x" ]; then
     frunning=0
   else
-    kill -0 $fpid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $fpid -o cmd 2>/dev/null |grep freshclam >/dev/null 2>&1; then
+      frunning=1
+    else
       rm $fpidfile
       fpid=""
       frunning=0
-    else
-      frunning=1
     fi
   fi
 }

--- a/src/bin/zmlogswatchctl
+++ b/src/bin/zmlogswatchctl
@@ -44,12 +44,11 @@ checkrunning()
   if [ "x$pid" = "x" ]; then
     running=0
   else
-    kill -0 $pid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null |grep swatchdog >/dev/null 2>&1; then
+      running=1
+    else
       pid=""
       running=0
-    else
-      running=1
     fi
   fi
 }
@@ -108,8 +107,7 @@ case "$1" in
           if [ -z "$zmrrdfetchpid" ]; then
               break;
           fi
-          kill -0 $zmrrdfetchpid 2> /dev/null
-          if [ $? != 0 ]; then
+          if ! ps --no-headers -p $zmrrdfetchpid -o cmd 2>/dev/null |grep zmrrdfetch >/dev/null 2>&1; then
               rm -f ${zmrrdfetchpidfile}
               break;
           fi
@@ -117,14 +115,12 @@ case "$1" in
           sleep 1
       done
       if [ -n "$zmrrdfetchpid" ]; then
-          kill -0 $zmrrdfetchpid 2> /dev/null
-          if [ $? = 0 ]; then
+          if ps --no-headers -p $zmrrdfetchpid -o cmd 2>/dev/null |grep zmrrdfetch >/dev/null 2>&1; then
               kill -9 $zmrrdfetchpid
           fi
       fi
       for ((i = 0; i < 30; i++)); do
-        kill -0 $pid 2> /dev/null
-        if [ $? != 0 ]; then
+        if ! ps --no-headers -p $pid -o cmd 2>/dev/null |grep swatchdog >/dev/null 2>&1; then
           rm -rf ${pidfile}
           break
         fi

--- a/src/bin/zmmemcachedctl
+++ b/src/bin/zmmemcachedctl
@@ -42,12 +42,11 @@ checkrunning()
   if [ "x$pid" = "x" ]; then
     running=0
   else
-    kill -0 $pid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null |grep memcached >/dev/null 2>&1; then
+      running=1
+    else
       pid=""
       running=0
-    else
-      running=1
     fi
   fi
 }

--- a/src/bin/zmopendkimctl
+++ b/src/bin/zmopendkimctl
@@ -51,12 +51,11 @@ checkrunning()
         if [ "x$PID" = "x" ]; then
                 RUNNING=0
         else
-                kill -0 $PID
-                if [ $? != 0 ]; then
+                if ps --no-headers -p $PID -o cmd 2>/dev/null | grep opendkim >/dev/null 2>&1; then
+                        RUNNING=1
+                else
                         PID=""
                         RUNNING=0
-                else
-                        RUNNING=1
                 fi
         fi
 }

--- a/src/bin/zmproxyctl
+++ b/src/bin/zmproxyctl
@@ -42,12 +42,11 @@ checkrunning()
   if [ "x$pid" = "x" ]; then
     running=0
   else
-    kill -0 $pid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null | grep nginx >/dev/null 2>&1; then
+      running=1
+    else
       pid=""
       running=0
-    else
-      running=1
     fi
   fi
 }

--- a/src/bin/zmsaslauthdctl
+++ b/src/bin/zmsaslauthdctl
@@ -45,12 +45,11 @@ checkrunning()
   if [ "x$pid" = "x" ]; then
     running=0
   else
-    kill -0 $pid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null | grep saslauthd >/dev/null 2>&1; then
+      running=1
+    else
       pid=""
       running=0
-    else
-      running=1
     fi
   fi
 }

--- a/src/bin/zmswatchctl
+++ b/src/bin/zmswatchctl
@@ -42,12 +42,11 @@ checkrunning()
   if [ "x$pid" = "x" ]; then
     running=0
   else
-    kill -0 $pid 2> /dev/null
-    if [ $? != 0 ]; then
+    if ps --no-headers -p $pid -o cmd 2>/dev/null | grep swatchdog >/dev/null 2>&1; then
+      running=1
+    else
       pid=""
       running=0
-    else
-      running=1
     fi
   fi
 }

--- a/src/libexec/zmmtastatus
+++ b/src/libexec/zmmtastatus
@@ -39,6 +39,7 @@ $verbose = 1 if $debug;
 
 
 my $pidFile="/opt/zimbra/data/postfix/spool/pid/master.pid";
+my $postfixMaster="/opt/zimbra/common/libexec/master";
 
 exit (mtaIsRunning() ? 0 : 1);
 
@@ -49,8 +50,7 @@ sub mtaIsRunning {
     chomp $pid;
     if ($pid ne "") {
       print "MTA process $pid is "  if $verbose;
-      system("kill -0 $pid 2> /dev/null");
-      if ($? == 0) {
+      if (readlink("/proc/$pid/exe") eq $postfixMaster) {
         print "running.\n" if $verbose;
         return 1;
       } else {

--- a/src/libexec/zmmtastatus
+++ b/src/libexec/zmmtastatus
@@ -21,7 +21,7 @@ use Getopt::Std;
 use File::Basename;
 
 my $progname = basename($0);
-# Need to be root to read the master.pid
+# Need to be root to run "postfix status"
 if ($> != 0) {
   print "$0 must be run as root.\n";
   exit 1;
@@ -38,25 +38,18 @@ my $verbose = $options{v} ? 1 : 0;
 $verbose = 1 if $debug;
 
 
-my $pidFile="/opt/zimbra/data/postfix/spool/pid/master.pid";
-my $postfixMaster="/opt/zimbra/common/libexec/master";
+my $postfix="/opt/zimbra/common/sbin/postfix";
 
 exit (mtaIsRunning() ? 0 : 1);
 
 sub mtaIsRunning {
-  if (-f "$pidFile") {
-    my $pid = qx(cat $pidFile);
-    $pid =~ s/^\s+//;
-    chomp $pid;
-    if ($pid ne "") {
-      print "MTA process $pid is "  if $verbose;
-      if (readlink("/proc/$pid/exe") eq $postfixMaster) {
-        print "running.\n" if $verbose;
-        return 1;
-      } else {
-        print "not running.\n" if $verbose;
-      }
-    }
+  print "MTA process is " if $verbose;
+  system("$postfix status 2> /dev/null");
+  if ($? == 0) {
+    print "running.\n" if $verbose;
+    return 1;
+  } else {
+    print "not running.\n" if $verbose;
   }
   return undef;
 }


### PR DESCRIPTION
A number of utilities, in particular `/opt/zimbra/libexec/zmmtastatus` used a mechanism for checking whether something was running by checking whether a process - any process with the same PID as was recorded in a file was running.  This can lead to problems if a process dies or a system gets restarted and some unrelated process gets that PID.

For `zmmtastatus` we defer to Robert Scheck's fix to use `postfix status`.

Also addressed some other utilities where this PID file issue occurs and uses a more robust mechanism where the process for the process ID from the pid file is checked to see if it has the right name.

Also for `/opt/zimbra/bin/ldap` tidied up the indentation a lot, simplified the logic and reduced the potential waiting time for startup or shutdown to resolve.