### PR TITLE
ZCS-8014: Third party vulnerabilities in dom4j

### DIFF
--- a/src/bin/zmlocalconfig
+++ b/src/bin/zmlocalconfig
@@ -53,7 +53,7 @@ ${PATHSEP}${ZMROOT}/lib/jars/commons-codec-1.7.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/guava-23.0.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/httpclient-4.5.2.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/httpcore-4.4.5.jar\
-${PATHSEP}${ZMROOT}/lib/jars/dom4j-1.5.2.jar\
+${PATHSEP}${ZMROOT}/lib/jars/dom4j-2.1.1.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/log4j-1.2.16.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/json.jar\
 ${PATHSEP}${ZMROOT}/lib/jars/activation-1.1.1.jar\


### PR DESCRIPTION
Issue: Third-party vulnerabilities in dom4j
Fix: Upgrade dom4j to the latest version