### PR TITLE
Unable to collect zmdiaglog after upgrading to ZCS 8.8.15 p5

### DIFF
--- a/src/libexec/zmdiaglog
+++ b/src/libexec/zmdiaglog
@@ -91,7 +91,10 @@ sub get_java_version() {
     open( JAVA, "$JAVA -version 2>&1 |" )
       || die "Cannot determine java version: $!";
     my $version_line = <JAVA>;
-    if ( $version_line =~ /"11\.0/ ) {
+    if ( $version_line =~ /"13\.0/ ) {
+        $version = "13.0";
+    }
+    elsif ( $version_line =~ /"11\.0/ ) {
         $version = "11.0";
     }
     elsif ( $version_line =~ /"1\.8/ ) {


### PR DESCRIPTION
Issue:  Error for openjdk version 13 while running the command zmdiaglog
Fix: Added a check for jdk13 in the code base
