### PR TITLE
ZBUG-1055:zmdiaglog not capturing top, ps and netstat on non-mailbox

### DIFF
--- a/src/libexec/zmdiaglog
+++ b/src/libexec/zmdiaglog
@@ -2,7 +2,7 @@
 #
 # ***** BEGIN LICENSE BLOCK *****
 # Zimbra Collaboration Suite Server
-# Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+# Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2020 Synacor, Inc.
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software Foundation,
@@ -363,11 +363,11 @@ sub run() {
             my $top_cmd = "top -bc -n1 > top.$i.$TS 2>&1";
             if ($isMac) {
                 $top_cmd = "top -o cpu -l 2 | \
-	                        awk 'BEGIN { sample = 0 } \
-	                            { \
-	                                if ( \$0 ~ /^Processes: / ) { sample++; } \
-	                                if ( sample ==2 ) { print \$0 } \
-	                            }' > top.$i.$TS 2>&1";
+                                awk 'BEGIN { sample = 0 } \
+                                    { \
+                                        if ( \$0 ~ /^Processes: / ) { sample++; } \
+                                        if ( sample ==2 ) { print \$0 } \
+                                    }' > top.$i.$TS 2>&1";
             }
             system($top_cmd);
             system("/bin/ps -auxw > ps.$i.$TS 2>&1");
@@ -524,6 +524,25 @@ sub run() {
     }
     else {
         logmsg "Not a mailboxd node or mailboxd not running. Not performing threaddump and pstack collection activities.\n";
+        for ( my $i = 1 ; $i <= 10 ; $i++ ) {
+            logmsg "Collecting top/ps/netstat: $i of 10\n";
+            my $TS = strftime( "%H-%M-%S", localtime() );
+            my $top_cmd = "top -bc -n1 > top.$i.$TS 2>&1";
+            if ($isMac) {
+                $top_cmd = "top -o cpu -l 2 | \
+                                awk 'BEGIN { sample = 0 } \
+                                    { \
+                                        if ( \$0 ~ /^Processes: / ) { sample++; } \
+                                        if ( sample ==2 ) { print \$0 } \
+                                    }' > top.$i.$TS 2>&1";
+            }
+            system($top_cmd);
+            system("/bin/ps -auxw > ps.$i.$TS 2>&1");
+            my $netstat = "netstat -anp > netstat.$i.$TS 2>&1";
+            $netstat = "netstat -an > netstat.$i.$TS 2>&1" if ($isMac);
+            system($netstat);
+            sleep(5);
+        }
     }
 
     if ($HAVE_LSOF) {


### PR DESCRIPTION
Issue: zmdiaglog not capturing top, ps and netstat on a non-mailbox server

Fix: collecting top, ps and netstat output if mailbox pid is not present

Testing done:
Tested on a non-mailbox server - top, ps and netstat commands are now getting collected
Tested on a mailbox server - top, ps, netstat, thread stats/stacks continue getting collected