### PR TITLE
Update to fix upstream change to iostat

### DIFF
--- a/src/bin/zmstat-chart-config
+++ b/src/bin/zmstat-chart-config
@@ -91,7 +91,7 @@ sub getDiskInfo() {
             return;
         }
         my $line = '';
-        while ($line !~ /^Device:/) {
+        while ($line !~ /^Device/) {
             $line = readLine(*IOSTAT, 1);
         }
         while (defined($line = readLine(*IOSTAT, 1))) {


### PR DESCRIPTION
iostat recently changed the output and removed the colon that was previously part of the output. We need to look for Device now instead of Device:.