### PR TITLE
Convert OpenSSH private key to OpenSSL PEM format

### DIFF
--- a/src/bin/zmsshkeygen
+++ b/src/bin/zmsshkeygen
@@ -47,6 +47,12 @@ fi
 ssh-keygen -f ${keyfile} -b 2048 -N '' \
 	-t ${keytype} -C ${zimbra_server_hostname}
 
+# Starting with OpenSSH 7.8 by default, the key is created with the OpenSSH private key format instead of the OpenSSL PEM format.
+# Check the format of KEY, and create KEY in OpenSSL PEM format.
+grep "BEGIN OPENSSH PRIVATE KEY" ${keyfile} > /dev/null 2>&1
+  if [ $? = 0 ]; then
+     ssh-keygen -m PEM -f ${keyfile}  -b 2048 -N '' \ -t ${keytype} -C ${zimbra_server_hostname}
+  fi
 pubkey=`cat ${keyfile}.pub`
 
 ${zmprov} ms ${zimbra_server_hostname} ${keyattr} "${pubkey}"

--- a/src/bin/zmsshkeygen
+++ b/src/bin/zmsshkeygen
@@ -48,10 +48,10 @@ ssh-keygen -f ${keyfile} -b 2048 -N '' \
 	-t ${keytype} -C ${zimbra_server_hostname}
 
 # Starting with OpenSSH 7.8 by default, the key is created with the OpenSSH private key format instead of the OpenSSL PEM format.
-# Check the format of KEY, and create KEY in OpenSSL PEM format.
+# Check the format of KEY and convert to OpenSSL PEM format.
 grep "BEGIN OPENSSH PRIVATE KEY" ${keyfile} > /dev/null 2>&1
   if [ $? = 0 ]; then
-     ssh-keygen -m PEM -f ${keyfile}  -b 2048 -N '' \ -t ${keytype} -C ${zimbra_server_hostname}
+     ssh-keygen -p -m PEM -f ${keyfile}  -b 2048 -N '' -t ${keytype} -C ${zimbra_server_hostname}
   fi
 pubkey=`cat ${keyfile}.pub`
 


### PR DESCRIPTION
**Problem :** 
SSH version in RHEL8 : OpenSSH_7.8p1
$ ssh -V
OpenSSH_7.8p1, OpenSSL 1.1.1 FIPS  11 Sep 2018

Starting with OpenSSH 7.8 by default, the key is created with the OpenSSH private key format instead of the OpenSSL PEM format.
Refer: https://www.openssh.com/txt/release-7.8
When we login to zimbra Admin , due to OpenSSH private key format, it is throwing below exception.
**Caused by**: java.io.IOException: Invalid PEM structure, '-----BEGIN...' missing
    at ch.ethz.ssh2.crypto.PEMDecoder.parsePEM(PEMDecoder.java:138)

Please refer : https://github.com/hudson/ganymed-ssh-2/blob/5fe3de29a7499f4efbe959cf11fb92d28752852c/src/main/java/ch/ethz/ssh2/crypto/PEMDecoder.java#L141

**Solution:**
If key is in OpenSSH private key format we need to convert into OpenSSL PEM format.