### PR TITLE
ZBUG-1441 : Default openldap configuration files with incorrect permissions

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -677,6 +677,14 @@ if [[ "x$PLAT" == "xRHEL7_64" && ! -d /opt/zimbra/.cache ]]; then
   chmod 775 /opt/zimbra/.cache
 fi
 
+# Fix permissions for default openldap configuration files
+for i in slapd.conf slapd.conf.default slapd.ldif slapd.ldif.default;
+do
+  if [ -f /opt/zimbra/common/etc/openldap/${i} ]; then
+    chown -f ${root_user}:${root_group} /opt/zimbra/common/etc/openldap/${i}
+    chmod 644 /opt/zimbra/common/etc/openldap/${i}
+  fi
+done
 
 exit 0
 


### PR DESCRIPTION
NG-Backup is stopping because it cannot read files that have the wrong permissions.
Getting below warnings from backup notification.

Warnings:
- File /opt/zimbra/common/etc/openldap/slapd.conf is not readable
- File /opt/zimbra/common/etc/openldap/slapd.conf.default is not readable
- File /opt/zimbra/common/etc/openldap/slapd.ldif is not readable
- File /opt/zimbra/common/etc/openldap/slapd.ldif.default is not readable