### PR TITLE
ZCS-9372 : Error while running /opt/zimbra/libexec/zmstatuslog on Centos6

### DIFF
--- a/src/libexec/zmstatuslog
+++ b/src/libexec/zmstatuslog
@@ -16,11 +16,11 @@
 # ***** END LICENSE BLOCK *****
 # 
 
+use lib "/opt/zimbra/common/lib/perl5";
 use strict;
 use JSON::PP;
 use Data::Dumper;
 
-use lib "/opt/zimbra/common/lib/perl5";
 use  Zimbra::Util::Common;
 use Zimbra::Mon::Logger;
 


### PR DESCRIPTION
**Problem :**
$$# /opt/zimbra/libexec/zmstatuslog
Can't locate JSON/PP.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at /opt/zimbra/libexec/zmstatuslog line 20.
BEGIN failed--compilation aborted at /opt/zimbra/libexec/zmstatuslog line 20.

JSON/PP.pm  is not available in CentOS 6 , perl version is v5.10.1.
It is present in zimbra perl lib.