### PR TITLE
Fix regex match for iostat output in zmstat-io

### DIFF
--- a/src/libexec/zmstat-io
+++ b/src/libexec/zmstat-io
@@ -86,7 +86,7 @@ sub getHeading($) {
     while ($line !~ /^Device/) {
         $line = readLine(*HEADING, 1);
     }
-    $line =~ s/^Device\s+//;
+    $line =~ s/^Device:?\s+//;
     my @devs;
     my @dev_cols = split('\s+', $line);
     $line = readLine(*HEADING, 1);


### PR DESCRIPTION
Pull request #64 fixed reading the output of iostat from version 11+, but it broke the output on systems running earlier versions of iostat.
On those now you can see a mismatch between the number of columns in the header and in the data section.
You can see columns in the header such as `sdb:Device:` which should not appeear. That's fixed with the small regex correction in this PR.