### PR TITLE
Make `ldap_replication_retry` a zmlocalconfig tunable

### DIFF
--- a/src/libexec/zmldapenable-mmr
+++ b/src/libexec/zmldapenable-mmr
@@ -71,6 +71,7 @@ chomp($ldap_root_password);
 my $ldap_is_master = $localxml->{key}->{ldap_is_master}->{value};
 chomp($ldap_is_master);
 my $ldap_replication_password = $localxml->{key}->{ldap_replication_password}->{value};
+my $ldap_replication_retry = $localxml->{key}->{ldap_replication_retry}->{value};
 my $ldap_starttls_supported = $localxml->{key}->{ldap_starttls_supported}->{value};
 my $zimbra_require_interprocess_security = $localxml->{key}->{zimbra_require_interprocess_security}->{value};
 
@@ -197,17 +198,17 @@ if(lc($ldap_is_master) eq "true") {
   if ($mmrURI =~ /^ldaps:/) {
     $mesg = $ldap->modify(
       $bdn,
-      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
+      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
     );
   } elsif ($ldap_starttls_supported && $zimbra_require_interprocess_security) {
     $mesg = $ldap->modify(
       $bdn,
-      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password starttls=critical filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
+      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password starttls=critical filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
     );
   } else {
     $mesg = $ldap->modify(
       $bdn,
-      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
+      add=>{olcSyncrepl=>"rid=$rid provider=$mmrURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"},
     );
   }
   $mesg = $ldap ->search(

--- a/src/libexec/zmldapenablereplica
+++ b/src/libexec/zmldapenablereplica
@@ -55,6 +55,7 @@ my $localxml = XMLin("/opt/zimbra/conf/localconfig.xml");
 my $ldap_root_password = $localxml->{key}->{ldap_root_password}->{value};
 chomp($ldap_root_password);
 my $ldap_replication_password = $localxml->{key}->{ldap_replication_password}->{value};
+my $ldap_replication_retry = $localxml->{key}->{ldap_replication_retry}->{value};
 my $ldap_starttls_supported = $localxml->{key}->{ldap_starttls_supported}->{value};
 my $zimbra_require_interprocess_security = $localxml->{key}->{zimbra_require_interprocess_security}->{value};
 my $zimbra_server_hostname = $localxml->{key}->{zimbra_server_hostname}->{value};
@@ -232,7 +233,7 @@ sub createLdapConfig {
     $mesg = $ldap->modify(
       $bdn,
       add=>[
-        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
+        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
         olcUpdateRef=>"$lmr",
       ],
     );
@@ -240,7 +241,7 @@ sub createLdapConfig {
     $mesg = $ldap->modify(
       $bdn,
       add=>[
-        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password starttls=critical filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
+        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password starttls=critical filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
         olcUpdateRef=>"$lmr",
       ],
     );
@@ -248,7 +249,7 @@ sub createLdapConfig {
     $mesg = $ldap->modify(
       $bdn,
       add=>[
-        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
+        olcSyncrepl=>"rid=100 provider=$lmr bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30",
         olcUpdateRef=>"$lmr",
       ],
     );

--- a/src/libexec/zmldapreplicatool
+++ b/src/libexec/zmldapreplicatool
@@ -66,11 +66,14 @@ my $ldap_root_password = $localxml->{key}->{ldap_root_password}->{value};
 my $ldap_is_master     = $localxml->{key}->{ldap_is_master}->{value};
 my $ldap_replication_password =
   $localxml->{key}->{ldap_replication_password}->{value};
+my $ldap_replication_retry =
+  $localxml->{key}->{ldap_replication_retry}->{value};
 my $ldap_starttls_supported =
   $localxml->{key}->{ldap_starttls_supported}->{value};
 my $zimbra_require_interprocess_security =
   $localxml->{key}->{zimbra_require_interprocess_security}->{value};
-chomp( $ldap_is_master, $ldap_root_password, $ldap_replication_password );
+chomp( $ldap_is_master, $ldap_root_password, $ldap_replication_password,
+  $ldap_replication_retry );
 
 die "ERROR: Cannot be used on a LDAP master.\n"
   if ( lc($ldap_is_master) eq "true" );
@@ -183,7 +186,7 @@ if ($add) {
             $bdn,
             add => {
                 olcSyncrepl =>
-"rid=$rid provider=$providerURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password $tls filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"
+"rid=$rid provider=$providerURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password $tls filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"
             },
         );
     }
@@ -192,7 +195,7 @@ if ($add) {
             $bdn,
             add => {
                 olcSyncrepl =>
-"rid=$rid provider=$providerURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"60 +\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"
+"rid=$rid provider=$providerURI bindmethod=simple timeout=0 network-timeout=0 binddn=uid=zmreplica,cn=admins,cn=zimbra credentials=$ldap_replication_password filter=\"(objectclass=*)\" searchbase=\"\" logfilter=\"(&(objectClass=auditWriteObject)(reqResult=0))\" logbase=cn=accesslog scope=sub schemachecking=off type=refreshAndPersist retry=\"$ldap_replication_retry\" syncdata=accesslog tls_cacertdir=/opt/zimbra/conf/ca keepalive=240:10:30"
             },
         );
         $err = $mesg->code;


### PR DESCRIPTION
to make the LDAP replication retry behaviour configurable, instead of the currently hardcoded value `60 +` (which should be make the default value for backwards compatibility).

From `man 5 slapd.conf`:

> If an error occurs during replication, the consumer will attempt to reconnect according to the retry parameter which is  a  list of the <retry interval> and <# of retries> pairs.  For example, retry="60 10 300 3" lets the consumer retry every 60 seconds for the first 10 times and then retry every 300 seconds for the next 3 times before stop retrying. The '+' in <# of  retries>  means indefinite number of retries until success.  If no retry was specified, by default syncrepl retries every hour forever.