### PR TITLE
ZBUG-1843: RHEL8 zimbra.log & zimbra-stats.log

### DIFF
--- a/src/libexec/zmsyslogsetup
+++ b/src/libexec/zmsyslogsetup
@@ -316,6 +316,9 @@ sub updateSyslog {
         if ($platform eq "RHEL7_64") {
       		s/#su zimbra zimbra/su zimbra zimbra/;
       	}
+	if ($platform eq "RHEL8_64") {
+		s/syslog\*.pid/rsyslogd.pid/g;
+	}
       }
       s/USER/zimbra/;
       s/GROUP/zimbra/;


### PR DESCRIPTION
The gist of the issue is that both /var/log/zimbra.log & /var/log/zimbra-stats.log do not get written to after logrotate has ran; /etc/logrotate.d/zimbra

logrotate config file is looking for incorrect pid file (syslog.pid).   

Rsyslog's pid file name changed on CentOS 8/RHEL 8 versions and it is available as rsyslog.pid. 