### PR TITLE
feature/ZCS-10060 : Convert private key to RSA private key format

### DIFF
--- a/src/bin/zmsshkeygen
+++ b/src/bin/zmsshkeygen
@@ -38,6 +38,7 @@ rm -f ${keyfile}
 
 keytype=${1:-rsa}
 
+
 if [ $keytype != "rsa" ]; then
 	echo "Bad keytype: $keytype"
 	echo ""
@@ -53,6 +54,13 @@ grep "BEGIN OPENSSH PRIVATE KEY" ${keyfile} > /dev/null 2>&1
   if [ $? = 0 ]; then
      ssh-keygen -p -m PEM -f ${keyfile}  -b 2048 -N '' -t ${keytype} -C ${zimbra_server_hostname}
   fi
+
+# Convert PRIVATE KEY TO RSA PRIVATE KEY FORMAT
+grep "BEGIN PRIVATE KEY" ${keyfile} > /dev/null 2>&1
+  if [ $? = 0 ]; then
+      /opt/zimbra/common/bin/openssl rsa -in ${keyfile} -out ${keyfile}
+  fi
+
 pubkey=`cat ${keyfile}.pub`
 
 ${zmprov} ms ${zimbra_server_hostname} ${keyattr} "${pubkey}"


### PR DESCRIPTION
**Problem**: The private key which is starting with `-----BEGIN PRIVATE KEY-----` not accepted by Trilead SSH-2 library , getting below exception.

Caused by: java.io.IOException: PEM problem: it is of unknown type. Supported algorithms are :[ssh-ed25519, ecdsa-sha2-nistp521, ecdsa-sha2-nistp384, ecdsa-sha2-nistp256, rsa-sha2-256, rsa-sha2-512, ssh-rsa, ssh-dss]

**Solution**: Convert private key to RSA private key format , which is supported by Trilead SSH-2 library.