### PR TITLE
ZBUG-1146: fixed classpath in zmskindeploy

### DIFF
--- a/src/bin/zmskindeploy
+++ b/src/bin/zmskindeploy
@@ -76,7 +76,7 @@ if [ x${BASE_URL} = 'x/' ]; then
   BASE_URL=""
 fi
 
-CP="/opt/zimbra/lib/jars/zimbracommon.jar:${SKIN_WORK_BASE}/WEB-INF/lib/*"
+CP="/opt/zimbra/lib/jars/zimbracommon.jar:/opt/zimbra/lib/jars/commons-cli-1.2.jar:${SKIN_WORK_BASE}/WEB-INF/lib/*"
 
 # Make sure source exists, and copy it to working dir
 if [ -d "$SKIN_SRC" ]; then


### PR DESCRIPTION
**Problem:**
The following error was raised when zmskindeploy was executed.
```
Error: Unable to initialize main class com.zimbra.kabuki.tools.img.ImageMerger
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/cli/ParseException
```

**Fix:**
* Add `/opt/zimbra/lib/jars/commons-cli-1.2.jar` to classpath