### PR TITLE
modify to ldap_url to ldap_master_url

### DIFF
--- a/src/libexec/zmaltermimeconfig
+++ b/src/libexec/zmaltermimeconfig
@@ -55,7 +55,7 @@ $c{zmprov}="/opt/zimbra/bin/zmprov -l --";
 # ***** Main *****
 my $ldappass = qx($c{zmlocalconfig} -s -m nokey zimbra_ldap_password);
 my $ldapdn  = qx($c{zmlocalconfig} -s -m nokey zimbra_ldap_userdn);
-my $ldapurl  = qx($c{zmlocalconfig} -s -m nokey ldap_url);
+my $ldapurl  = qx($c{zmlocalconfig} -s -m nokey ldap_master_url);
 chop($ldappass);
 chop($ldapdn);
 chop($ldapurl);


### PR DESCRIPTION
when use enable domain, this script try to write to ldap.
ldap_url can contain slave ldap so it should use ldap_master_url instead.