### PR TITLE
ZBUG-2411 - zmdhparam is broken

### DIFF
--- a/src/bin/zmdhparam
+++ b/src/bin/zmdhparam
@@ -380,7 +380,7 @@ them (Proxy/MTA/LDAP) are restarted.
     sub getNewDHParam {
         my ( $self, $file ) = @_;
         return join( "",
-            $self->run( $self->Openssl, "dhparam", $self->New, "-out", $file )
+            $self->run( $self->Openssl, "dhparam",  "-out", $file, $self->New )
         );
     }
 


### PR DESCRIPTION
This is happening due to a change in the order of arguments for newer versions of openssl.

This fails:

 openssl dhparam 2048 -out /tmp/file

While this works:

 openssl dhparam -out /tmp/file 2048