### PR TITLE
ZCS-10242 : Mariadb master-master setup

### DIFF
--- a/src/libexec/zmmysqlenable-mmr
+++ b/src/libexec/zmmysqlenable-mmr
@@ -56,10 +56,10 @@ configure_mysql_mycnf(){
 check_server_id(){
 	mysql_mycnf="`zmlocalconfig -s -m nokey mysql_mycnf`"
 	server_id="`/opt/zimbra/libexec/zminiutil --section=mysqld --key=binlog_format --get --key=server-id $mysql_mycnf`"
-	maridb_master=$1
+	maridb_primary=$1
 	if [ ! -z "$server_id" ]
 	then
-		echo "Error: Server ID $server_id is already configured for $maridb_master"
+		echo "Error: Server ID $server_id is already configured for $maridb_primary"
 		exit 1
 	fi
 }
@@ -71,7 +71,7 @@ create_replication_user(){
 		zmlocalconfig -r -f -e mysql_replicator_password
 	fi
 	mysql_replicator_password="`zmlocalconfig -s -m nokey mysql_replicator_password`"
-	mysql -e "create user 'zmreplicator'@'%' identified by '$mysql_replicator_password';"
+	mysql -e "create user if not exists 'zmreplicator'@'%' identified by '$mysql_replicator_password';"
 	mysql -e "grant replication slave on *.* to 'zmreplicator'@'%';"
 	mysql -e "flush privileges;"
 }
@@ -79,26 +79,38 @@ create_replication_user(){
 restart_mysql(){
 	mysql.server restart
 }
-maridb_master1="`zmlocalconfig -s -m nokey maridb_master1| cut -f1 -d :`"
-maridb_master2="`zmlocalconfig -s -m nokey maridb_master2| cut -f1 -d :`"
+
+check_data_before_start(){
+	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
+    if [ -z "$maridb_primary" ]; then
+		echo "Error: $1 from zmlocalconfig not found"
+		echo "Error: please first set $1 using zmlocalconfig"
+		exit 1
+	fi
+}
+
+check_data_before_start maridb_primary1
+check_data_before_start maridb_primary2
+maridb_primary1="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
+maridb_primary2="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"
 ip_address=$(hostname -I)
 ip_address=(${ip_address//" "/ })
 for ip in "${ip_address[@]}";
 do
-  # Assign server-id=1 for maridb_master1
-  if [ "$ip" == "$maridb_master1" ]; then
-	 check_server_id $maridb_master1
+  # Assign server-id=1 for maridb_primary1
+  if [ "$ip" == "$maridb_primary1" ]; then
+	 check_server_id $maridb_primary1
 	 server_id=1
-     configure_mysql_mycnf $maridb_master1 $server_id
+     configure_mysql_mycnf $maridb_primary1 $server_id
 	 create_replication_user
 	 restart_mysql
   fi
   
-  # Assign server-id=2 for maridb_master2
-  if [ "$ip" == "$maridb_master2" ]; then
-	 check_server_id $maridb_master2
+  # Assign server-id=2 for maridb_primary2
+  if [ "$ip" == "$maridb_primary2" ]; then
+	 check_server_id $maridb_primary2
 	 server_id=2
-	 configure_mysql_mycnf $maridb_master2 $server_id
+	 configure_mysql_mycnf $maridb_primary2 $server_id
 	 create_replication_user
 	 restart_mysql
   fi	  

--- a/src/libexec/zmmysqlenable-mmr
+++ b/src/libexec/zmmysqlenable-mmr
@@ -81,16 +81,24 @@ restart_mysql(){
 }
 
 check_data_before_start(){
+	return_value=""
 	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
     if [ -z "$maridb_primary" ]; then
-		echo "Error: $1 from zmlocalconfig not found"
-		echo "Error: please first set $1 using zmlocalconfig"
-		exit 1
+		return_value="false"
+		echo "$return_value"
+	else
+		return_value="true"
+		echo "$return_value"
 	fi
 }
 
-check_data_before_start maridb_primary1
-check_data_before_start maridb_primary2
+maridb_primary_1=$(check_data_before_start maridb_primary1)
+maridb_primary_2=$(check_data_before_start maridb_primary2)
+if [ "${maridb_primary_1}" = "false" ] || [ "${maridb_primary_2}" = "false" ]; then
+	echo "Error: maridb_primary1 and maridb_primary2 are not found in zmlocalconfig"
+	echo "Error: please first set maridb_primary1 and maridb_primary2 using zmlocalconfig"
+	exit 1
+fi
 maridb_primary1="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
 maridb_primary2="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"
 ip_address=$(hostname -I)

--- a/src/libexec/zmmysqlenable-mmr
+++ b/src/libexec/zmmysqlenable-mmr
@@ -1,0 +1,105 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+if [ x`whoami` != "xzimbra" ]; then
+  echo "Error: must be run as user zimbra"
+  exit 1
+fi
+
+source /opt/zimbra/bin/zmshutil || exit 1
+zmsetvars -f
+
+#
+# Sanity checks
+#
+zmassert -x /opt/zimbra/common/bin/mysqladmin
+zmassert -x /opt/zimbra/common/bin/mysql
+zmassert -x /opt/zimbra/bin/zmlocalconfig
+zmassert -x /opt/zimbra/bin/zmcontrol
+zmassert -r ${zimbra_db_directory}/db.sql
+if [ ! -x /opt/zimbra/common/bin/mysql ]; then
+  echo "Mysql not found on this host"
+  exit 1
+fi
+
+configure_mysql_mycnf(){
+	 mysql_mycnf="`zmlocalconfig -s -m nokey mysql_mycnf`"
+	 backup_date=`date +%Y-%m-%d`
+	 /opt/zimbra/libexec/zminiutil --backup=.pre-${backup_date}-bind-address --section=mysqld --key=bind-address --unset $mysql_mycnf
+	 /opt/zimbra/libexec/zminiutil --backup=.pre-${backup_date}-server-id --section=mysqld --key=server-id --set --value=$2 $mysql_mycnf
+	 /opt/zimbra/libexec/zminiutil --backup=.pre-${backup_date}-log_bin --section=mysqld --key=log_bin --set --value=/opt/zimbra/log/mysql-bin.log $mysql_mycnf
+	 /opt/zimbra/libexec/zminiutil --backup=.pre-${backup_date}-binlog_format --section=mysqld --key=binlog_format --set --value=row $mysql_mycnf
+	 server_id="`/opt/zimbra/libexec/zminiutil --section=mysqld --key=binlog_format --get --key=server-id $mysql_mycnf`"
+	 if [ -z "$server_id" ]
+	 then
+	       echo "Error: Failed to configure Server ID $server_id for $1"
+		   exit 1
+	 else
+	       echo "Info: Server ID $server_id is configured for $1"
+	 fi
+}
+
+check_server_id(){
+	mysql_mycnf="`zmlocalconfig -s -m nokey mysql_mycnf`"
+	server_id="`/opt/zimbra/libexec/zminiutil --section=mysqld --key=binlog_format --get --key=server-id $mysql_mycnf`"
+	maridb_master=$1
+	if [ ! -z "$server_id" ]
+	then
+		echo "Error: Server ID $server_id is already configured for $maridb_master"
+		exit 1
+	fi
+}
+
+create_replication_user(){
+	mysql_replicator_password="`zmlocalconfig -s -m nokey mysql_replicator_password 2>/dev/null`"
+    if [ -z "$mysql_replicator_password" ]
+    then
+		zmlocalconfig -r -f -e mysql_replicator_password
+	fi
+	mysql_replicator_password="`zmlocalconfig -s -m nokey mysql_replicator_password`"
+	mysql -e "create user 'zmreplicator'@'%' identified by '$mysql_replicator_password';"
+	mysql -e "grant replication slave on *.* to 'zmreplicator'@'%';"
+	mysql -e "flush privileges;"
+}
+
+restart_mysql(){
+	mysql.server restart
+}
+maridb_master1="`zmlocalconfig -s -m nokey maridb_master1| cut -f1 -d :`"
+maridb_master2="`zmlocalconfig -s -m nokey maridb_master2| cut -f1 -d :`"
+ip_address=$(hostname -I)
+ip_address=(${ip_address//" "/ })
+for ip in "${ip_address[@]}";
+do
+  # Assign server-id=1 for maridb_master1
+  if [ "$ip" == "$maridb_master1" ]; then
+	 check_server_id $maridb_master1
+	 server_id=1
+     configure_mysql_mycnf $maridb_master1 $server_id
+	 create_replication_user
+	 restart_mysql
+  fi
+  
+  # Assign server-id=2 for maridb_master2
+  if [ "$ip" == "$maridb_master2" ]; then
+	 check_server_id $maridb_master2
+	 server_id=2
+	 configure_mysql_mycnf $maridb_master2 $server_id
+	 create_replication_user
+	 restart_mysql
+  fi	  
+done

--- a/src/libexec/zmmysqlmmr-status
+++ b/src/libexec/zmmysqlmmr-status
@@ -45,6 +45,7 @@ check_server_id(){
 		echo "Mariadb Primary1 is $maridb_primary1_host"
 		echo "Mariadb Primary2 is $maridb_primary2_host"
 		echo "Server ID is not yet configured for $maridb_master"
+		exit 1
 	else
 		echo "ServerID is $server_id"
 		echo "Server is $maridb_master"
@@ -63,21 +64,30 @@ replication_info(){
 	Exec_Master_Log_Pos="`mysql 2>/dev/null -e "SHOW SLAVE STATUS\G;" | grep Exec_Master_Log_Pos| tail -n 1 | awk {'print $2'}`"
 	echo "Exec_Master_Log_Pos : $Exec_Master_Log_Pos"
     if [ "$Read_Master_Log_Pos" == "$Exec_Master_Log_Pos" ]; then
-  	    echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are in sync, so databases are in sync"
-	else
-		echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are not in sync, so databases are not in sync. Something wrong with replication"
+        echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are in sync and databases also are in sync"
+   else
+	echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are not in sync, so databases are not in sync. Something wrong with replication"
     fi
 }
 check_data_before_start(){
+	return_value=""
 	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
     if [ -z "$maridb_primary" ]; then
-		echo "Error: $1 from zmlocalconfig not found"
-		echo "Error: please first set $1 using zmlocalconfig"
-		exit 1
+		return_value="false"
+		echo "$return_value"
+	else
+		return_value="true"
+		echo "$return_value"
 	fi
 }
-check_data_before_start maridb_primary1
-check_data_before_start maridb_primary2
+
+maridb_primary_1=$(check_data_before_start maridb_primary1)
+maridb_primary_2=$(check_data_before_start maridb_primary2)
+if [ "${maridb_primary_1}" = "false" ] || [ "${maridb_primary_2}" = "false" ]; then
+	echo "Error: maridb_primary1 and maridb_primary2 are not found in zmlocalconfig"
+	echo "Error: please first set maridb_primary1 and maridb_primary2 using zmlocalconfig"
+	exit 1
+fi
 maridb_primary1_host="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
 maridb_primary1_port="`zmlocalconfig -s -m nokey maridb_primary1| cut -f2 -d :`"
 maridb_primary2_host="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"

--- a/src/libexec/zmmysqlmmr-status
+++ b/src/libexec/zmmysqlmmr-status
@@ -1,0 +1,98 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+if [ x`whoami` != "xzimbra" ]; then
+  echo "Error: must be run as user zimbra"
+  exit 1
+fi
+
+source /opt/zimbra/bin/zmshutil || exit 1
+zmsetvars -f
+
+#
+# Sanity checks
+#
+zmassert -x /opt/zimbra/common/bin/mysqladmin
+zmassert -x /opt/zimbra/common/bin/mysql
+zmassert -x /opt/zimbra/bin/zmlocalconfig
+zmassert -x /opt/zimbra/bin/zmcontrol
+zmassert -r ${zimbra_db_directory}/db.sql
+if [ ! -x /opt/zimbra/common/bin/mysql ]; then
+  echo "Mysql not found on this host"
+  exit 1
+fi
+
+check_server_id(){
+	mysql_mycnf="`zmlocalconfig -s -m nokey mysql_mycnf`"
+	server_id="`/opt/zimbra/libexec/zminiutil --section=mysqld --key=binlog_format --get --key=server-id $mysql_mycnf`"
+	maridb_master=$1
+	echo "Server information:"
+	if [ -z "$server_id" ]; then
+		echo "Mariadb Primary1 is $maridb_primary1_host"
+		echo "Mariadb Primary2 is $maridb_primary2_host"
+		echo "Server ID is not yet configured for $maridb_master"
+	else
+		echo "ServerID is $server_id"
+		echo "Server is $maridb_master"
+	fi
+}
+
+replication_info(){
+	echo "------------------------"
+	echo "Replication information:"
+    Slave_IO_Running="`mysql 2>/dev/null -e "SHOW SLAVE STATUS\G;" | grep Slave_IO_Running| tail -n 1 | awk {'print $2'}`"
+	echo "Slave_IO_Running : $Slave_IO_Running"
+	Slave_SQL_Running="`mysql 2>/dev/null -e "SHOW SLAVE STATUS\G;" | grep Slave_SQL_Running| tail -n 1 | awk {'print $2'}`"
+	echo "Slave_SQL_Running : $Slave_SQL_Running"
+    Read_Master_Log_Pos="`mysql 2>/dev/null -e "SHOW SLAVE STATUS\G;" | grep Read_Master_Log_Pos| tail -n 1 | awk {'print $2'}`"
+	echo "Read_Master_Log_Pos : $Read_Master_Log_Pos"
+	Exec_Master_Log_Pos="`mysql 2>/dev/null -e "SHOW SLAVE STATUS\G;" | grep Exec_Master_Log_Pos| tail -n 1 | awk {'print $2'}`"
+	echo "Exec_Master_Log_Pos : $Exec_Master_Log_Pos"
+    if [ "$Read_Master_Log_Pos" == "$Exec_Master_Log_Pos" ]; then
+  	    echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are in sync, so databases are in sync"
+	else
+		echo "Read_Master_Log_Pos and Exec_Master_Log_Pos are not in sync, so databases are not in sync. Something wrong with replication"
+    fi
+}
+check_data_before_start(){
+	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
+    if [ -z "$maridb_primary" ]; then
+		echo "Error: $1 from zmlocalconfig not found"
+		echo "Error: please first set $1 using zmlocalconfig"
+		exit 1
+	fi
+}
+check_data_before_start maridb_primary1
+check_data_before_start maridb_primary2
+maridb_primary1_host="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
+maridb_primary1_port="`zmlocalconfig -s -m nokey maridb_primary1| cut -f2 -d :`"
+maridb_primary2_host="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"
+maridb_primary2_port="`zmlocalconfig -s -m nokey maridb_primary2| cut -f2 -d :`"
+ip_address=$(hostname -I)
+ip_address=(${ip_address//" "/ })
+for ip in "${ip_address[@]}";
+do
+  if [ "$ip" == "$maridb_primary1_host" ]; then
+	 check_server_id $maridb_primary1_host
+	 replication_info
+  fi
+  
+  if [ "$ip" == "$maridb_primary2_host" ]; then
+	 check_server_id $maridb_primary2_host
+	 replication_info
+  fi	  
+done

--- a/src/libexec/zmmysqlstart-mmr
+++ b/src/libexec/zmmysqlstart-mmr
@@ -1,0 +1,154 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Server
+# Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+
+if [ x`whoami` != "xzimbra" ]; then
+  echo "Error: must be run as user zimbra"
+  exit 1
+fi
+
+source /opt/zimbra/bin/zmshutil || exit 1
+zmsetvars -f
+
+#
+# Sanity checks
+#
+zmassert -x /opt/zimbra/common/bin/mysqladmin
+zmassert -x /opt/zimbra/common/bin/mysql
+zmassert -x /opt/zimbra/bin/zmlocalconfig
+zmassert -x /opt/zimbra/bin/zmcontrol
+zmassert -r ${zimbra_db_directory}/db.sql
+if [ ! -x /opt/zimbra/common/bin/mysql ]; then
+  echo "Mysql not found on this host"
+  exit 1
+fi
+
+validate_input(){
+	input_value=$1
+    if [ -z "$input_value" ]
+    then
+		echo "Error: You have entered empty value"
+		exit 1
+	fi
+}
+
+check_server_id(){
+	mysql_mycnf="`zmlocalconfig -s -m nokey mysql_mycnf`"
+	server_id="`/opt/zimbra/libexec/zminiutil --section=mysqld --key=binlog_format --get --key=server-id $mysql_mycnf`"
+	maridb_master=$1
+	if [ -z "$server_id" ]
+	then
+		echo "Error: Server ID is not yet configured for $maridb_master"
+		echo "Info: First run /opt/zimbra/libexec/zmmysqlenable-mmr on $maridb_master to configure Server ID" 
+		exit 1
+	fi
+}
+
+get_required_passwords(){
+	mysql_master_host=$1
+	mysql_master_port=$2
+	read -p "Please provide zimbra_mysql_password of $mysql_master_host: " mysql_master_password
+	validate_input $mysql_master_password
+	read -p "Please provide mysql_replicator_password of $mysql_master_host: " mysql_master_replicator_password
+	validate_input $mysql_master_replicator_password
+}
+get_master_log_file(){
+	mysql_master_host=$1
+	mysql_master_port=$2
+	mysql_master_password=$3
+	master_log_file="`mysql 2>/dev/null -h $mysql_master_host -P $mysql_master_port -u zimbra --password=$mysql_master_password -e "show master status" -s | tail -n 1 | awk {'print $1'}`"
+    if [ $? != 0 ]; then
+		echo "Error: Failed to get master_log_file of $master_log_file"
+		exit 1
+	fi	
+}
+
+get_master_log_pos(){
+    mysql_master_host=$1
+	mysql_master_port=$2
+	mysql_master_password=$3
+    master_log_pos="`mysql 2>/dev/null -h $mysql_master_host -P $mysql_master_port -u zimbra --password=$mysql_master_password -e "show master status" -s | tail -n 1 | awk {'print $2'}`"
+    if [ $? != 0 ]; then
+		echo "Error: Failed to get master_log_pos of $master_log_file"
+		exit 1
+	fi
+}
+
+configure_binary_log_position(){
+	mysql_master_host=$1
+	mysql_master_port=$2
+	mysql_master_replicator_password=$3
+	master_log_file=$4
+	master_log_pos=$5
+	mysql -e "CHANGE MASTER TO MASTER_HOST = '$mysql_master_host', MASTER_USER = 'zmreplicator', MASTER_PASSWORD = '$mysql_master_replicator_password', MASTER_PORT = $mysql_master_port, MASTER_LOG_FILE = '$master_log_file', MASTER_LOG_POS = $master_log_pos; 
+"   
+    if [ $? != 0 ]; then
+	   echo "Error: Failed to configure binary log positions"
+	   exit 1
+   else
+	   echo "Info: Configured binary log positions successfully" 
+    fi
+
+}
+stop_slave(){
+	echo "Info: Stopping mysql slave process"
+    mysql -e "stop slave;"
+    if [ $? != 0 ]; then
+		echo "Error: Failed to stop mysql slave process"
+		exit 1
+	else
+		echo "Info: Mysql slave process stopped successfully"
+	fi
+}
+
+start_slave(){
+	echo "Info: Starting mysql slave process"
+    mysql -e "start slave;"
+    if [ $? != 0 ]; then
+		echo "Error: Failed to start mysql slave process"
+		exit 1
+	else
+		echo "Info: Mysql slave process started successfully"
+	fi
+}
+maridb_master1_host="`zmlocalconfig -s -m nokey maridb_master1| cut -f1 -d :`"
+maridb_master1_port="`zmlocalconfig -s -m nokey maridb_master1| cut -f2 -d :`"
+maridb_master2_host="`zmlocalconfig -s -m nokey maridb_master2| cut -f1 -d :`"
+maridb_master2_port="`zmlocalconfig -s -m nokey maridb_master2| cut -f2 -d :`"
+ip_address=$(hostname -I)
+ip_address=(${ip_address//" "/ })
+for ip in "${ip_address[@]}";
+do
+  if [ "$ip" == "$maridb_master1_host" ]; then
+	 check_server_id $maridb_master1_host
+	 get_required_passwords $maridb_master2_host $maridb_master2_port
+	 get_master_log_file $maridb_master2_host $maridb_master2_port $mysql_master_password
+	 get_master_log_pos $maridb_master2_host $maridb_master2_port $mysql_master_password
+	 stop_slave
+	 configure_binary_log_position $maridb_master2_host $maridb_master2_port $mysql_master_replicator_password $master_log_file $master_log_pos
+	 start_slave
+  fi
+  
+  if [ "$ip" == "$maridb_master2_host" ]; then
+	 check_server_id $maridb_master2_host
+ 	 get_required_passwords $maridb_master1_host $maridb_master1_port
+ 	 get_master_log_file $maridb_master1_host $maridb_master1_port $mysql_master_password
+ 	 get_master_log_pos $maridb_master1_host $maridb_master1_port $mysql_master_password
+ 	 stop_slave
+ 	 configure_binary_log_position $maridb_master1_host $maridb_master1_port $mysql_master_replicator_password $master_log_file $master_log_pos
+ 	 start_slave
+  fi	  
+done

--- a/src/libexec/zmmysqlstart-mmr
+++ b/src/libexec/zmmysqlstart-mmr
@@ -126,15 +126,24 @@ start_slave(){
 }
 
 check_data_before_start(){
+	return_value=""
 	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
     if [ -z "$maridb_primary" ]; then
-		echo "Error: $1 from zmlocalconfig not found"
-		echo "Error: please first set $1 using zmlocalconfig"
-		exit 1
+		return_value="false"
+		echo "$return_value"
+	else
+		return_value="true"
+		echo "$return_value"
 	fi
 }
-check_data_before_start maridb_primary1
-check_data_before_start maridb_primary2
+
+maridb_primary_1=$(check_data_before_start maridb_primary1)
+maridb_primary_2=$(check_data_before_start maridb_primary2)
+if [ "${maridb_primary_1}" = "false" ] || [ "${maridb_primary_2}" = "false" ]; then
+	echo "Error: maridb_primary1 and maridb_primary2 are not found in zmlocalconfig"
+	echo "Error: please first set maridb_primary1 and maridb_primary2 using zmlocalconfig"
+	exit 1
+fi
 maridb_primary1_host="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
 maridb_primary1_port="`zmlocalconfig -s -m nokey maridb_primary1| cut -f2 -d :`"
 maridb_primary2_host="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"

--- a/src/libexec/zmmysqlstart-mmr
+++ b/src/libexec/zmmysqlstart-mmr
@@ -124,31 +124,42 @@ start_slave(){
 		echo "Info: Mysql slave process started successfully"
 	fi
 }
-maridb_master1_host="`zmlocalconfig -s -m nokey maridb_master1| cut -f1 -d :`"
-maridb_master1_port="`zmlocalconfig -s -m nokey maridb_master1| cut -f2 -d :`"
-maridb_master2_host="`zmlocalconfig -s -m nokey maridb_master2| cut -f1 -d :`"
-maridb_master2_port="`zmlocalconfig -s -m nokey maridb_master2| cut -f2 -d :`"
+
+check_data_before_start(){
+	maridb_primary="`zmlocalconfig -s -m nokey $1 2>/dev/null`"
+    if [ -z "$maridb_primary" ]; then
+		echo "Error: $1 from zmlocalconfig not found"
+		echo "Error: please first set $1 using zmlocalconfig"
+		exit 1
+	fi
+}
+check_data_before_start maridb_primary1
+check_data_before_start maridb_primary2
+maridb_primary1_host="`zmlocalconfig -s -m nokey maridb_primary1| cut -f1 -d :`"
+maridb_primary1_port="`zmlocalconfig -s -m nokey maridb_primary1| cut -f2 -d :`"
+maridb_primary2_host="`zmlocalconfig -s -m nokey maridb_primary2| cut -f1 -d :`"
+maridb_primary2_port="`zmlocalconfig -s -m nokey maridb_primary2| cut -f2 -d :`"
 ip_address=$(hostname -I)
 ip_address=(${ip_address//" "/ })
 for ip in "${ip_address[@]}";
 do
-  if [ "$ip" == "$maridb_master1_host" ]; then
-	 check_server_id $maridb_master1_host
-	 get_required_passwords $maridb_master2_host $maridb_master2_port
-	 get_master_log_file $maridb_master2_host $maridb_master2_port $mysql_master_password
-	 get_master_log_pos $maridb_master2_host $maridb_master2_port $mysql_master_password
+  if [ "$ip" == "$maridb_primary1_host" ]; then
+	 check_server_id $maridb_primary1_host
+	 get_required_passwords $maridb_primary2_host $maridb_primary2_port
+	 get_master_log_file $maridb_primary2_host $maridb_primary2_port $mysql_master_password
+	 get_master_log_pos $maridb_primary2_host $maridb_primary2_port $mysql_master_password
 	 stop_slave
-	 configure_binary_log_position $maridb_master2_host $maridb_master2_port $mysql_master_replicator_password $master_log_file $master_log_pos
+	 configure_binary_log_position $maridb_primary2_host $maridb_primary2_port $mysql_master_replicator_password $master_log_file $master_log_pos
 	 start_slave
   fi
   
-  if [ "$ip" == "$maridb_master2_host" ]; then
-	 check_server_id $maridb_master2_host
- 	 get_required_passwords $maridb_master1_host $maridb_master1_port
- 	 get_master_log_file $maridb_master1_host $maridb_master1_port $mysql_master_password
- 	 get_master_log_pos $maridb_master1_host $maridb_master1_port $mysql_master_password
+  if [ "$ip" == "$maridb_primary2_host" ]; then
+	 check_server_id $maridb_primary2_host
+ 	 get_required_passwords $maridb_primary1_host $maridb_primary1_port
+ 	 get_master_log_file $maridb_primary1_host $maridb_primary1_port $mysql_master_password
+ 	 get_master_log_pos $maridb_primary1_host $maridb_primary1_port $mysql_master_password
  	 stop_slave
- 	 configure_binary_log_position $maridb_master1_host $maridb_master1_port $mysql_master_replicator_password $master_log_file $master_log_pos
+ 	 configure_binary_log_position $maridb_primary1_host $maridb_primary1_port $mysql_master_replicator_password $master_log_file $master_log_pos
  	 start_slave
   fi	  
 done


### PR DESCRIPTION
**Mariadb master-master setup**

Two example hostnames will be used throughout this process.
master1.example.com (Primary master) master2.example.com (Secondary master)


`zmmysqlenable-mmr` : Enable replication on both servers
`zmmysqlstart-mmr` :    Start replication between both servers

**Data to have before starting**

The below data we should have for both mariadb servers before starting mariadb master-master setup
zimbra_mysql_password
mysql_replicator_password
mysql_port

**Enable replication on both servers**

- On both mariadb servers set below values

    `zmlocalconfig -e maridb_master1="master1.example.com:7306" `
    `zmlocalconfig -e maridb_master2="master2.example.com:7306"`

- Run `zmmysqlenable-mmr` on both mariadb servers

    `zmmysqlenable-mmr` will do the following steps
           

1. Add the following to `/opt/zimbra/conf/my.cnf`

       server-id
       log_bin
       binlog_format
       remove bind-address entry
        

2. Create replication user
3.  restart mysql

- Run `zmmysqlstart-mmr` on both mariadb servers

    `zmmysqlstart-mmr` will require `zimbra_mysql_password` , `mysql_replicator_password`

     `zmmysqlstart-mmr` will do the following steps

1.       Get inputs `zimbra_mysql_password` , `mysql_replicator_password` from user
2.       Get `MASTER_LOG_FILE` and `MASTER_LOG_POS`
3.       Stop Mysql Slave thread
4.       Set `MASTER_LOG_FILE` and `MASTER_LOG_POS`
5.       Star Mysql Slave thread



