### PR TITLE
ZBUG-2492 : Added condition to change permission to zimbra

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -151,6 +151,10 @@ if [ -d /opt/zimbra ]; then
     chown ${zimbra_user}:${zimbra_group} /opt/zimbra/.platform
   fi
 
+  if [ -d /opt/zimbra/.saveconfig/ ]; then
+    chown ${zimbra_user}:${zimbra_group} /opt/zimbra/.saveconfig/
+  fi
+
   for i in .zmmailbox_history .zmprov_history .bash_history; do
     if [ ! -f /opt/zimbra/${i} ]; then
       touch /opt/zimbra/${i}


### PR DESCRIPTION
Issue :- zmfixperms script does not fix .saveconfig directory ownership. I am able to reproduce this issue on zcs 8.8.15 p26.

Expected output: zmfixperms should change the ".saveconfig" ownership to zimbra.

Solution : Added condition to change permission of .saveconfig directory to zimbra user when running the script