### PR TITLE
ZBUG-2155: Regex correction in zmresolverctl

### DIFF
--- a/src/bin/zmresolverctl
+++ b/src/bin/zmresolverctl
@@ -18,4 +18,4 @@
 
 resolver_file=/opt/zimbra/conf/nginx/resolvers.conf
 cat /dev/null > ${resolver_file}
-[ -r /etc/resolv.conf ] && awk 'BEGIN{ns="";sep=""}/nameserver/{ns=ns sep $2;sep=" " }; END{ if (ns) {print "resolver " ns ";"} }' /etc/resolv.conf >> ${resolver_file}
+[ -r /etc/resolv.conf ] && awk 'BEGIN{ns="";sep=""}/^nameserver/{ns=ns sep $2;sep=" " }; END{ if (ns) {print "resolver " ns ";"} }' /etc/resolv.conf >> ${resolver_file}


### PR DESCRIPTION
Issue :- Due to the current regex, all disable and unwanted text extracted from the "/etc/resolv.conf" and injected into the Nginx resolver "/opt/zimbra/conf/nginx/resolvers.conf". 

```
root@mail:~# cat /etc/resolv.conf
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
# DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "systemd-resolve --status" to see details about the actual nameservers.
# nameserver 169.254.169.254
nameserver 127.0.0.53
search myztestdom.com 
Actual:
root@mail:~# awk 'BEGIN{ns="";sep=""}/nameserver/{ns=ns sep $2;sep=" " }; END{ if (ns) {print "resolver " ns ";"} }' /etc/resolv.conf
resolver run 169.254.169.254 127.0.0.53;
root@mail:~#
Expected: 
root@mail:~# awk 'BEGIN{ns="";sep=""}/nameserver/{ns=ns sep $2;sep=" " }; END{ if (ns) {print "resolver " ns ";"} }' /etc/resolv.conf
resolver 127.0.0.53;
```

Solution : Updated regex to ignore commented lines. Will only consider the value when it matches at the beginning of input line 
```
root@mail:~# cat /etc/resolv.conf
# Dynamic resolv.conf(5) file for glibc resolver(3) generated by resolvconf(8)
# DO NOT EDIT THIS FILE BY HAND -- YOUR CHANGES WILL BE OVERWRITTEN
# 127.0.0.53 is the systemd-resolved stub resolver.
# run "systemd-resolve --status" to see details about the actual nameservers.
# nameserver 169.254.169.254
nameserver 127.0.0.53
search myztestdom.com 
Now:
root@mail:~# awk 'BEGIN{ns="";sep=""}/^nameserver/{ns=ns sep $2;sep=" " }; END{ if (ns) {print "resolver " ns ";"} }' /etc/resolv.conf
resolver 127.0.0.53;
```