### PR TITLE
ZBUG-2358: sa-update --allowplugins workaround

### DIFF
--- a/src/libexec/zmsaupdate
+++ b/src/libexec/zmsaupdate
@@ -54,8 +54,10 @@ if (!$rule_updates_enabled) {
   exit;
 }
 
+my $really_allow_plugins = getLocalConfig("antispam_saupdate_reallyallowplugins");
+   $really_allow_plugins = $really_allow_plugins =~ /true/ ? "--reallyallowplugins" : "";
+my $sa="/opt/zimbra/common/bin/sa-update -v $really_allow_plugins --refreshmirrors >/dev/null 2>&1";
 
-my $sa="/opt/zimbra/common/bin/sa-update -v --allowplugins --refreshmirrors >/dev/null 2>&1";
 my $restart="/opt/zimbra/bin/zmamavisdctl restart norewrite >/dev/null 2>&1";
 my $compile="/opt/zimbra/libexec/zmsacompile >/dev/null 2>&1";
 


### PR DESCRIPTION
Problem: The --allowplugins option is now considered harmful by the SpamAssassin developers. If one really wishes to use it, they must specify --reallyallowplugins.

Fix: Added support for an LC option to use --reallyallowplugins in case customers need it.

Testing: See [ZBUG-2358](https://jira.corp.synacor.com/browse/ZBUG-2358?focusedCommentId=1665520&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1665520) for details.