### PR TITLE
ZBUG-2671: Initialize the messageId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .project
+.idea

--- a/src/libexec/zmmsgtrace
+++ b/src/libexec/zmmsgtrace
@@ -460,7 +460,7 @@ sub doit {
                     unless ($ref) {
                         $ref = $obj->{recipList}->{$recip} = {};
                     }
-
+                    $ref->{messageId}  ||= "[unknown:$key]";
                     $ref->{leaveTime} = $date;
                     $ref->{origRecip} = $2 if $2;
 
@@ -483,7 +483,7 @@ sub doit {
 
                         push(@msgs, $obj);
                     }
-
+                    $obj->{messageId}  ||= "[unknown:$key]";
                     $msgs{ $obj->{messageId} }{$qid} = $obj;
                 }
                 else {

--- a/src/libexec/zmmsgtrace
+++ b/src/libexec/zmmsgtrace
@@ -483,7 +483,6 @@ sub doit {
 
                         push(@msgs, $obj);
                     }
-                    $obj->{messageId}  ||= "[unknown:$key]";
                     $msgs{ $obj->{messageId} }{$qid} = $obj;
                 }
                 else {


### PR DESCRIPTION
In cases where the messageID cannot be found in the line, the script was still attempting to push the messageID into 