### PR TITLE
ZBUG-2671 Initialize the messageId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .project
+.idea

--- a/src/libexec/zmmsgtrace
+++ b/src/libexec/zmmsgtrace
@@ -461,6 +461,7 @@ sub doit {
                         $ref = $obj->{recipList}->{$recip} = {};
                     }
 
+                    $ref->{messageId}  ||= "[unknown:$key]";
                     $ref->{leaveTime} = $date;
                     $ref->{origRecip} = $2 if $2;
 


### PR DESCRIPTION
This fixes ZBUG-2671. There are cases in which the messageId is being pushed to @msgs, but we have not yet seen the message ID. 

If messageID is empty, initialize it with unknown. to prevent hash errors.

@ronstra-synacor can you please verify this is doing what it should be? I'm not too great at perl.