### PR TITLE
ZCS-11112: Changes as per log4j-2.17.1

### DIFF
--- a/src/libexec/zmconfigd
+++ b/src/libexec/zmconfigd
@@ -29,7 +29,7 @@ import traceback
 
 import conf
 # import commands
-from org.apache.log4j import PropertyConfigurator
+from org.apache.logging.log4j.core.config import Configurator
 import state
 import listener
 from ldap import Ldap
@@ -162,7 +162,7 @@ state.State.mState = myState
 myConfig = conf.Config()
 conf.Config.mConfig = myConfig;
 myState.getLocalConfig(myConfig)
-PropertyConfigurator.configure("/opt/zimbra/conf/zmconfigd.log4j.properties")
+Configurator.initialize(None, "/opt/zimbra/conf/zmconfigd.log4j.properties")
 Log.initLogging(myConfig)
 Ldap.initLdap(myConfig)
 


### PR DESCRIPTION
Issue: Used log4j version was below 2.17.1

Solution Upgraded log4j version to 2.17.1 as well as did implementation for same.