### PR TITLE
ZBUG-2569: zimbraAmavisOutboundDisclaimersOnly changes should work af…

### DIFF
--- a/src/bin/zmmtactl
+++ b/src/bin/zmmtactl
@@ -31,11 +31,11 @@ fi
 zimbraMilterServerEnabled=${zimbraMilterServerEnabled:=FALSE}
 
 if [ x"$zimbraMilterServerEnabled" = "xTRUE" ]; then
-  START_SCRIPTS="zmmilterctl zmsaslauthdctl postfix"
-  STOP_SCRIPTS="postfix zmsaslauthdctl zmmilterctl"
+  START_SCRIPTS="zmamavisdctl zmmilterctl zmsaslauthdctl postfix"
+  STOP_SCRIPTS="postfix zmsaslauthdctl zmmilterctl zmamavisdctl"
 else 
-  START_SCRIPTS="zmsaslauthdctl postfix"
-  STOP_SCRIPTS="postfix zmsaslauthdctl"
+  START_SCRIPTS="zmamavisdctl zmsaslauthdctl postfix"
+  STOP_SCRIPTS="postfix zmsaslauthdctl zmamavisdctl"
 fi
 
 rewriteconfig() {


### PR DESCRIPTION
Ticket: https://jira.corp.synacor.com/browse/ZBUG-2569

zmamavisdctl is added to the zmmtactl to restart the amavis service to make the changes reflected after restart.

Test: 

1. Enable disclaimer for the Domain- https://wiki.zimbra.com/wiki/Steps_to_configure_per_domain_disclaimer_on_ZCS_8.5_and_higher_versions
2.  zmprov mcf zimbraAmavisOutboundDisclaimersOnly FALSE
3. zmmtactl restart (previously we had to restart the amavis service - "zmamavisdctl restart" along with MTA restart to make these changes work)
4. Send email from green@test1.com to red@test2.com and observe the attached disclaimer.

Notes: 
-  zimbraAmavisOutboundDisclaimersOnly FALSE - disclaimers can be set on internal domains
 - zimbraAmavisOutboundDisclaimersOnly TRUE -  disclaimers can be set on external domains
