### PR TITLE
ZCS-11481: Need API for scheduling HSM policy execution

### DIFF
--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -100,6 +100,9 @@ my %REGEX_CHECKED_COMMANDS = (
    "rsync" => {
      regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@= ]*',
      program => "rsync"},
+   "zmschedulesmpolicy" => {
+     regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@=* ]*',
+     program => "/opt/zimbra/bin/zmschedulesmpolicy"},
 );
 
 my %allhosts = ();

--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -101,7 +101,7 @@ my %REGEX_CHECKED_COMMANDS = (
      regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@= ]*',
      program => "rsync"},
    "zmschedulesmpolicy" => {
-     regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@=* ]*',
+     regex => '[\'"e-g0-9\\-: ]*',
      program => "/opt/zimbra/bin/zmschedulesmpolicy"},
 );
 


### PR DESCRIPTION
**Feature**
Need API for scheduling HSM policy execution.

**Solution**
Created API for scheduling HSM policy and also created a script **zmschedulesmpolicy** for schedule from command line.

**Options for zmschedulesmpolicy**

**-l: list** - print existing schedule
**-h: help** - get help about zmschedulesmpolicy (default command)
**-f: flush** - remove current schedule (cancel all scheduled Storage Management policy)
**-e: edit** - edit current schedule with specified schedule