### PR TITLE
ZCS-11602 : Notification support for quarantined devices

### DIFF
--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -102,9 +102,9 @@ my %REGEX_CHECKED_COMMANDS = (
    "rsync" => {
      regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@= ]*',
      program => "rsync"},
-   "zmemail" => {
-     regex => '(.*?)',
-     program => "/opt/zimbra/bin/zmemail"},
+   "zmmdmnotificationmail" => {
+     regex => '*',
+     program => "/opt/zimbra/bin/zmmdmnotificationmail"},
 
 );
 

--- a/src/libexec/zmrcd
+++ b/src/libexec/zmrcd
@@ -102,6 +102,10 @@ my %REGEX_CHECKED_COMMANDS = (
    "rsync" => {
      regex => '[\'"a-zA-Z0-9\\/\\.\\-_:@= ]*',
      program => "rsync"},
+   "zmemail" => {
+     regex => '(.*?)',
+     program => "/opt/zimbra/bin/zmemail"},
+
 );
 
 my %allhosts = ();


### PR DESCRIPTION
Feature :- Implemented regex for accepting all symbols and string in zmemail command.