### PR TITLE
ZCS-12164 Change permission of nginx log files

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -706,6 +706,16 @@ if [ -x /opt/zimbra/common/sbin/nginx ]; then
   chown ${root_user}:${zimbra_group} /opt/zimbra/common/sbin/nginx
   chmod 750 /opt/zimbra/common/sbin/nginx
 
+  if [ -f /opt/zimbra/log/nginx.log ]; then
+    chown ${zimbra_user}:${zimbra_group} /opt/zimbra/log/nginx.log
+    chmod 644 /opt/zimbra/log/nginx.log
+  fi
+
+  if [ -f /opt/zimbra/log/nginx.access.log ]; then
+    chown ${zimbra_user}:${zimbra_group} /opt/zimbra/log/nginx.access.log
+    chmod 644 /opt/zimbra/log/nginx.access.log
+  fi
+
   # changing permission will reset capabilities so set it again
   echo "Set capability for /opt/zimbra/common/sbin/nginx"
   setcap CAP_NET_BIND_SERVICE=+ep /opt/zimbra/common/sbin/nginx


### PR DESCRIPTION
- After upgrade proxy is not starting as log files are created with root permission
- issue is only happening in server where log rotation has not run once, as log rotation updates file permissions with zimbra user

Related PR https://github.com/Zimbra/zm-build/pull/242