### PR TITLE
ZCS-13429:Semantic Versioning for Z10

### DIFF
--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -542,7 +542,7 @@ sub displayVersion {
 			$string = "Release $release $platform";
 		}
 	} else {
-		my $release = qx(rpm -q --queryformat "%{version}_%{release}" zimbra-core);
+		$release = qx(rpm -q --queryformat "%{version}_%{release}" zimbra-core);
 		my $inst = localtime (qx(rpm -q --queryformat "%{installtime}" zimbra-core));
 		$string = "Release $release $platform";
 		$rpm_pkg_timestamp = qx(rpm -q --queryformat "%{release}" zimbra-core);

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -524,8 +524,14 @@ sub displayVersion {
 	my $platform = qx(/opt/zimbra/libexec/get_plat_tag.sh);
 	chomp $platform;
 	my $string = "";
+	my $current_patch_version = "";
+	my $new_patch_version = "";
+	my $release = "";
+	my $edition = "";
+	my $rpm_pkg_timestamp = "";
+
 	if ($platform =~ /DEBIAN/ || $platform =~ /UBUNTU/) {
-		my $release = qx(dpkg -s zimbra-core | egrep '^Version:' | sed -e 's/Version: //');
+		$release = qx(dpkg -s zimbra-core | egrep '^Version:' | sed -e 's/Version: //');
 		chomp $release;
 		if ( -x "/opt/vmware/bin/vamicli") {
 			my $appliance_version=qx(/opt/vmware/bin/vamicli version --appliance | awk '{if ((\$1 ~ /Version/) && (\$2 ~ /-/)) { print \$3} }' 2> /dev/null);
@@ -539,9 +545,11 @@ sub displayVersion {
 		my $release = qx(rpm -q --queryformat "%{version}_%{release}" zimbra-core);
 		my $inst = localtime (qx(rpm -q --queryformat "%{installtime}" zimbra-core));
 		$string = "Release $release $platform";
+		$rpm_pkg_timestamp = qx(rpm -q --queryformat "%{release}" zimbra-core);
 	}
 
-  $string .=  ((-f "/opt/zimbra/bin/zmbackupquery") ? " NETWORK" : " FOSS"); 
+  $edition .=  ((-f "/opt/zimbra/bin/zmbackupquery") ? " NETWORK" : " FOSS");
+  $string .= "$edition";
   $string .= " edition";
 
   my $patch = "";
@@ -570,9 +578,18 @@ sub displayVersion {
   }
   if ($patch ne "") {
     $string .= ", Patch $patch";
+    $new_patch_version = "$patch";$new_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic) = $new_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;$new_patch_version = "$mic";
+    $current_patch_version = "$release";$current_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic,my $rtype,my $build) = $current_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/; ($maj,$min,$mic,$rtype,$build) = $current_patch_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
+    if ($rpm_pkg_timestamp ne "") {
+	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform.$rpm_pkg_timestamp$edition edition.\n";
+    }else {
+	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform$edition edition.\n";
+    }
+
+  }else {
+	  print "$string.\n";
   }
 
-	print "$string.\n";
 }
 
 sub checkAvailableSpace {

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -577,7 +577,6 @@ sub displayVersion {
     close(HIST_FILE);
   }
   if ($patch ne "") {
-    $string .= ", Patch $patch";
     $new_patch_version = "$patch";$new_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic) = $new_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;$new_patch_version = "$mic";
     $current_patch_version = "$release";$current_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic,my $rtype,my $build) = $current_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/; ($maj,$min,$mic,$rtype,$build) = $current_patch_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
     if ($rpm_pkg_timestamp ne "") {

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -577,15 +577,21 @@ sub displayVersion {
     close(HIST_FILE);
   }
   if ($patch ne "") {
-    $new_patch_version = "$patch";$new_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic) = $new_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;$new_patch_version = "$mic";
-    $current_patch_version = "$release";$current_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;(my $maj,my $min,my $mic,my $rtype,my $build) = $current_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/; ($maj,$min,$mic,$rtype,$build) = $current_patch_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
+    $new_patch_version = "$patch";
+    $new_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
+    (my $maj, my $min, my $mic) = $new_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;
+    $new_patch_version = "$mic";
+    $current_patch_version = "$release";
+    $current_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
+    (my $maj, my $min, my $mic, my $rtype, my $build) = $current_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/;
+    ($maj, $min, $mic, $rtype, $build) = $current_patch_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
     if ($rpm_pkg_timestamp ne "") {
 	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform.$rpm_pkg_timestamp$edition edition.\n";
-    }else {
+    } else {
 	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform$edition edition.\n";
     }
 
-  }else {
+  } else {
 	  print "$string.\n";
   }
 

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -524,8 +524,8 @@ sub displayVersion {
 	my $platform = qx(/opt/zimbra/libexec/get_plat_tag.sh);
 	chomp $platform;
 	my $string = "";
-	my $current_patch_version = "";
-	my $new_patch_version = "";
+	my $base_version = "";
+	my $patch_version = "";
 	my $release = "";
 	my $edition = "";
 	my $rpm_pkg_timestamp = "";
@@ -577,18 +577,18 @@ sub displayVersion {
     close(HIST_FILE);
   }
   if ($patch ne "") {
-    $new_patch_version = "$patch";
-    $new_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
-    (my $maj, my $min, my $mic) = $new_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;
-    $new_patch_version = "$mic";
-    $current_patch_version = "$release";
-    $current_patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
-    (my $maj, my $min, my $mic, my $rtype, my $build) = $current_patch_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/;
-    ($maj, $min, $mic, $rtype, $build) = $current_patch_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
+    $patch_version = "$patch";
+    $patch_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
+    (my $maj, my $min, my $mic) = $patch_version =~ m/^(\d+)\.(\d+)\.(\d+)/;
+    $patch_version = "$mic";
+    $base_version = "$release";
+    $base_version =~ s/^(\d+\.\d+\.[^_]*_[^_]+_[^.]+).*/\1/;
+    (my $maj, my $min, my $mic, my $rtype, my $build) = $base_version =~ m/^(\d+)\.(\d+)\.(\d+)\.(\w+)\.(\d+)/;
+    ($maj, $min, $mic, $rtype, $build) = $base_version =~ m/(\d+)\.(\d+)\.(\d+)_(\w+[^_])_(\d+)/ if ($rtype eq "");
     if ($rpm_pkg_timestamp ne "") {
-	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform.$rpm_pkg_timestamp$edition edition.\n";
+	    print "Release $maj.$min.$patch_version.$rtype.$build.$platform.$rpm_pkg_timestamp$edition edition.\n";
     } else {
-	    print "Release $maj.$min.$new_patch_version.$rtype.$build.$platform$edition edition.\n";
+	    print "Release $maj.$min.$patch_version.$rtype.$build.$platform$edition edition.\n";
     }
 
   } else {


### PR DESCRIPTION
Follow proper semantic versioning for Daffodil patch.

With 8815/900, we are showing Patch P33 like this.

For Z10/Daffodil, while customer do zmcontrol -v, it will show patch version as per semantic, like below example

`Release 10.0.1.GA.4518.UBUNTU20_64 NETWORK edition `