### PR TITLE
ZCS-13314 : add zm-modules-porter to zimbra extensions path

### DIFF
--- a/src/bin/zmjava
+++ b/src/bin/zmjava
@@ -34,7 +34,7 @@ CYGWIN*) PATHSEP=";";;
 *) PATHSEP=":";;
 esac
 
-ZIMBRA_EXTENSIONS="backup clamscanner network zimbra-license zimbrahsm zimbrasync twofactorauth com_zimbra_ssdb_ephemeral_store zimbra-archive"
+ZIMBRA_EXTENSIONS="backup clamscanner network zimbra-license zimbrahsm zimbrasync twofactorauth com_zimbra_ssdb_ephemeral_store zimbra-archive zm-modules-porter"
 ZIMBRA_EXT_DIR="/opt/zimbra/lib/ext-common/*"
 for i in $ZIMBRA_EXTENSIONS; do
   if [ -d "/opt/zimbra/lib/ext/$i" ]; then


### PR DESCRIPTION
**Problem :**
 User gets ClassNotFound exception while using zimbra-modules-porter package after NG Mailbox in place upgrade from 9.0 to 10.0 using --skip-ng-check option

Getting `Could not find or load main class com.zimbra.porter.ZPortCLIUtil
Caused by: java.lang.ClassNotFoundException: com.zimbra.porter.ZPortCLIUtil` error while importing data/setting using zmmodulesport if using already installed package.

**Fix :**
`zm-modules-porter` needs to add to the zimbra extensions path to load by mailbox. This has been already taking care by zimbra-modules-porter package https://github.com/Zimbra/zm-modules-porter/blob/develop/scripts/postinst.sh#LL14C20-L14C20. But this is getting overridden by upgrade (9.0 to 10.0) because latest zimbra-core package will be installed in the upgrade and this will replace the file `/opt/zimbra/bin/zmjava`. 
