### PR TITLE
ZCS-13565 : use -fips option for PKCS12 file creation

### DIFF
--- a/src/bin/zmcertmgr
+++ b/src/bin/zmcertmgr
@@ -1815,7 +1815,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         my $kpass = $self->lc->get("mailboxd_keystore_password");
         print("** Creating file '$pkcsf'\n");
         @out = $self->run(
-            $self->Openssl, "pkcs12", "-nomac", "-inkey", $keyf,
+            $self->Openssl, "pkcs12", "-propquery", "-fips", "-inkey", $keyf,
             "-in",          $crtf,    "-name",  $server,
             "-export",      "-out",   $pkcsf,   "-passout",
             "pass:$kpass",  "2>&1"
@@ -1876,7 +1876,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         my $kpass = $self->lc->get("imapd_keystore_password");
         print("** Creating file '$pkcsf'\n");
         @out = $self->run(
-            $self->Openssl, "pkcs12", "-nomac", "-inkey", $keyf,
+            $self->Openssl, "pkcs12", "-propquery", "-fips", "-inkey", $keyf,
             "-in",          $crtf,    "-name",  $server,
             "-export",      "-out",   $pkcsf,   "-passout",
             "pass:$kpass",  "2>&1"

--- a/src/bin/zmcertmgr
+++ b/src/bin/zmcertmgr
@@ -1815,7 +1815,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         my $kpass = $self->lc->get("mailboxd_keystore_password");
         print("** Creating file '$pkcsf'\n");
         @out = $self->run(
-            $self->Openssl, "pkcs12", "-inkey", $keyf,
+            $self->Openssl, "pkcs12", "-nomac", "-inkey", $keyf,
             "-in",          $crtf,    "-name",  $server,
             "-export",      "-out",   $pkcsf,   "-passout",
             "pass:$kpass",  "2>&1"
@@ -1876,7 +1876,7 @@ use lib qw(/opt/zimbra/common/lib/perl5 /opt/zimbra/zimbramon/lib/);
         my $kpass = $self->lc->get("imapd_keystore_password");
         print("** Creating file '$pkcsf'\n");
         @out = $self->run(
-            $self->Openssl, "pkcs12", "-inkey", $keyf,
+            $self->Openssl, "pkcs12", "-nomac", "-inkey", $keyf,
             "-in",          $crtf,    "-name",  $server,
             "-export",      "-out",   $pkcsf,   "-passout",
             "pass:$kpass",  "2>&1"


### PR DESCRIPTION
zmcertmgr deploycrt self failing with OpenSSL 3.0.9

```
/opt/zimbra/bin/zmcertmgr deploycrt self
Installing imapd certificate '/opt/zimbra/conf/imapd.crt' and key '/opt/zimbra/conf/imapd.key'** Copying '/opt/zimbra/ssl/zimbra/server/server.crt' to '/opt/zimbra/conf/imapd.crt'** Copying '/opt/zimbra/ssl/zimbra/server/server.key' to '/opt/zimbra/conf/imapd.key'** Creating file '/opt/zimbra/ssl/zimbra/jetty.pkcs12'ERROR: openssl pkcs12 export to '/opt/zimbra/ssl/zimbra/jetty.pkcs12' failed(1):
 Error creating PKCS12 MAC; no PKCS12KDF support?
 Use -nomac if MAC not required and PKCS12KDF support not available.
 C0D1C7FA4A7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (PKCS12KDF : 192), Properties (<null>)
 C0D1C7FA4A7F0000:error:1180006B:PKCS12 routines:pkcs12_gen_mac:key gen error:crypto/pkcs12/p12_mutl.c:147:
 C0D1C7FA4A7F0000:error:1180006D:PKCS12 routines:PKCS12_set_mac:mac generation error:crypto/pkcs12/p12_mutl.c:220:
```