### PR TITLE
Update zmmilterctl for Log4j2 compatibility

### DIFF
--- a/src/bin/zmmilterctl
+++ b/src/bin/zmmilterctl
@@ -38,7 +38,7 @@ else
   java_options=""
 fi
 
-runcmd="${java} ${java_options} -Dlog4j.configuration=file:${log4jfile} -Dzimbra.home=\"/opt/zimbra\" -Dzimbra.config=\"${configfile}\" \
+runcmd="${java} ${java_options} -Dlog4j.configurationFile=file:${log4jfile} -Dzimbra.home=\"/opt/zimbra\" -Dzimbra.config=\"${configfile}\" \
    com.zimbra.cs.milter.MilterServer"
 
 getpid()


### PR DESCRIPTION
Log4j has been upgraded to version 2 since Zimbra 9.0.0-Patch-25 and 8.8.15-Patch-32