### PR TITLE
ZCS-14533:Enhance zmlicensectl command to set log level and run in offline mode

### DIFF
--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -237,7 +237,7 @@ sub doStatus {
 	foreach (sort keys %{$services}) {
 		if ($_ eq "syncshare") {next;}
 		if ($_ eq "license-daemon") {
-			$allservices{$_}="$allservices{$_} zmlicenseservice";
+			$allservices{$_}="$allservices{$_} --service";
 		}
 		my $rc = 0xffff & system ("$allservices{$_} status > $statusfile 2> $errfile");
 		$rc = $rc >> 8;
@@ -346,7 +346,7 @@ sub doStartup {
 			next;
 		}
 		if ($_ eq "license-daemon") {
-			$allservices{$_}="$allservices{$_} zmlicenseservice";
+			$allservices{$_}="$allservices{$_} --service";
 		}
 		$rrc = 0xffff & system ("$allservices{$_} start norewrite > $zmcontrolLogfile 2>&1");
 		$rrc = $rrc >> 8;
@@ -388,7 +388,7 @@ sub doShutdown {
 			next;
 		}
 		if ($_ eq "license-daemon") {
-			$allservices{$_}="$allservices{$_} zmlicenseservice";
+			$allservices{$_}="$allservices{$_} --service";
 		}
 		$rrc = 0xffff & system ("$allservices{$_} stop > $zmcontrolLogfile 2>&1");
 		$rrc = $rrc >> 8;

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -56,7 +56,7 @@ startLicenseDaemonService()
 	if [ "x$zimbra_license_daemon_log_level" = "x" ]; then
 		zimbra_license_daemon_log_level=ERROR
 	fi
-	if [ "x$zimbra_license_daemon_mode" = "x" ]; then
+	if [ "x$zimbra_license_daemon_offline_mode" = "x" ]; then
 		zimbra_license_daemon_offline_mode=false
 	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-dev-linux64.so ]; then

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -20,12 +20,18 @@ if [ x`whoami` != xzimbra ]; then
 	exit 1
 fi
 
+CONFIG_FILE=/opt/zimbra/license/config/license-daemon.cnf
 ZMJAVA="/opt/zimbra/common/lib/jvm/java/bin/java"
 LD_LIBRARY_PATH="/opt/zimbra/license/lib"
 LICENSE_DAEMON_SERVICE_OUTPUT="/opt/zimbra/log/license-daemon-service.log"
 LICENSE_DAEMON_SERVICE="/opt/zimbra/license/lib/app.jar"
 LICENSE_DAEMON_SERVICE_PORT="8081"
 licenseDaemonServicepid=""
+
+if [ ! -f ${CONFIG_FILE} ]; then
+      echo "Error: ${CONFIG_FILE} is missing."
+      exit 1
+fi
 
 checkLicenseDaemonServiceRunning()
 {
@@ -46,10 +52,17 @@ startLicenseDaemonService()
 		echo "license daemon service is already running."
 		return
 	fi
+	source $CONFIG_FILE
+	if [ "x$zimbra_license_daemon_log_level" = "x" ]; then
+		zimbra_license_daemon_log_level=DEBUG
+	fi
+	if [ "x$zimbra_license_daemon_mode" = "x" ]; then
+		zimbra_license_daemon_mode=offline
+	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-dev-linux64.so ]; then
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log=${zimbra_license_daemon_log_level} -Dlicense-daemon.mode=${zimbra_license_daemon_mode} --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	else
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.mode=${zimbra_license_daemon_log_level} -Dlicense-daemon.log=${zimbra_license_daemon_mode} --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	fi
 	sleep 5
 	checkLicenseDaemonServiceRunning
@@ -63,8 +76,17 @@ startLicenseDaemonService()
 	fi
 }
 
+displayHelp()
+{
+	echo "Usage: $0 [option...]"
+	echo
+	echo "   --service start|restart|stop"
+	echo "   --service setLogLevel=INFO|DEBUG|ERROR|TRACE"
+	echo "   --service setMode=offline|online"
+}
+
 case "$1" in
-	"zmlicenseservice")
+	"--service")
 		case "$2" in
 			"start")
 				startLicenseDaemonService
@@ -106,14 +128,32 @@ case "$1" in
 			  	fi
 			  	;;
 
+			"setLogLevel=INFO"|"setLogLevel=DEBUG"|"setLogLevel=ERROR"|"setLogLevel=TRACE")
+				loglevel=`echo $2|cut -d = -f 2`
+				sed -i "/zimbra_license_daemon_log_level*/c\zimbra_license_daemon_log_level="$loglevel"" $CONFIG_FILE
+				if [ $? != 0 ]; then
+					exit 1
+				fi
+				exit 0
+				;;
+
+			"setMode=online"|"setMode=offline")
+				mode=`echo $2|cut -d = -f 2`
+				sed -i "/zimbra_license_daemon_mode*/c\zimbra_license_daemon_mode="$mode"" $CONFIG_FILE
+				if [ $? != 0 ]; then
+					exit 1
+				fi
+				exit 0
+				;;
+
 			*)
-				echo "Usage: $0 $1 start|stop|restart|status"
+				displayHelp
 				exit 1
 				;;
 		esac
 		;;
 	*)
-		echo "Usage: $0 zmlicenseservice start|stop|restart|status"
+		displayHelp
 		exit 1
 		;;
 esac

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -60,9 +60,9 @@ startLicenseDaemonService()
 		zimbra_license_daemon_offline_mode=false
 	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-dev-linux64.so ]; then
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	else
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	fi
 	sleep 5
 	checkLicenseDaemonServiceRunning

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -54,7 +54,7 @@ startLicenseDaemonService()
 	fi
 	source $CONFIG_FILE
 	if [ "x$zimbra_license_daemon_log_level" = "x" ]; then
-		zimbra_license_daemon_log_level=INFO
+		zimbra_license_daemon_log_level=ERROR
 	fi
 	if [ "x$zimbra_license_daemon_mode" = "x" ]; then
 		zimbra_license_daemon_mode=online

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -54,10 +54,10 @@ startLicenseDaemonService()
 	fi
 	source $CONFIG_FILE
 	if [ "x$zimbra_license_daemon_log_level" = "x" ]; then
-		zimbra_license_daemon_log_level=DEBUG
+		zimbra_license_daemon_log_level=INFO
 	fi
 	if [ "x$zimbra_license_daemon_mode" = "x" ]; then
-		zimbra_license_daemon_mode=offline
+		zimbra_license_daemon_mode=online
 	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-dev-linux64.so ]; then
 		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log=${zimbra_license_daemon_log_level} -Dlicense-daemon.mode=${zimbra_license_daemon_mode} --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -81,7 +81,7 @@ displayHelp()
 	echo "Usage: $0 [option...]"
 	echo
 	echo "   --service start|restart|stop"
-	echo "   --service setLogLevel=INFO|DEBUG|ERROR|TRACE"
+	echo "   --service setLogLevel=INFO|DEBUG|ERROR|WARN"
 	echo "   --service setOfflineMode=true|false"
 }
 
@@ -128,7 +128,7 @@ case "$1" in
 			  	fi
 			  	;;
 
-			"setLogLevel=INFO"|"setLogLevel=DEBUG"|"setLogLevel=ERROR"|"setLogLevel=TRACE")
+			"setLogLevel=INFO"|"setLogLevel=DEBUG"|"setLogLevel=ERROR"|"setLogLevel=WARN")
 				loglevel=`echo $2|cut -d = -f 2`
 				sed -i "/zimbra_license_daemon_log_level*/c\zimbra_license_daemon_log_level="$loglevel"" $CONFIG_FILE
 				if [ $? != 0 ]; then

--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -57,12 +57,12 @@ startLicenseDaemonService()
 		zimbra_license_daemon_log_level=ERROR
 	fi
 	if [ "x$zimbra_license_daemon_mode" = "x" ]; then
-		zimbra_license_daemon_mode=online
+		zimbra_license_daemon_offline_mode=false
 	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-dev-linux64.so ]; then
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log=${zimbra_license_daemon_log_level} -Dlicense-daemon.mode=${zimbra_license_daemon_mode} --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	else
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.mode=${zimbra_license_daemon_log_level} -Dlicense-daemon.log=${zimbra_license_daemon_mode} --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -jar $LICENSE_DAEMON_SERVICE -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
 	fi
 	sleep 5
 	checkLicenseDaemonServiceRunning
@@ -82,7 +82,7 @@ displayHelp()
 	echo
 	echo "   --service start|restart|stop"
 	echo "   --service setLogLevel=INFO|DEBUG|ERROR|TRACE"
-	echo "   --service setMode=offline|online"
+	echo "   --service setOfflineMode=true|false"
 }
 
 case "$1" in
@@ -137,9 +137,9 @@ case "$1" in
 				exit 0
 				;;
 
-			"setMode=online"|"setMode=offline")
-				mode=`echo $2|cut -d = -f 2`
-				sed -i "/zimbra_license_daemon_mode*/c\zimbra_license_daemon_mode="$mode"" $CONFIG_FILE
+			"setOfflineMode=true"|"setOfflineMode=false")
+				offlineMode=`echo $2|cut -d = -f 2`
+				sed -i "/zimbra_license_daemon_offline_mode*/c\zimbra_license_daemon_offline_mode="$offlineMode"" $CONFIG_FILE
 				if [ $? != 0 ]; then
 					exit 1
 				fi


### PR DESCRIPTION
- We should not need of extra parameter of zmlicenseservice to pass zmlicensectl command
- Ability to control daemon service `zmlicensectl --service start|restart|stop`
- Ability to set license daemon service log level `zmlicensectl --service setLogLevel=INFO|DEBUG|ERROR|TRACE`
- Ability to set license daemon service mode `zmlicensectl --service setMode=offline|online`

Related PR : https://github.com/Zimbra/zm-license-daemon-service/pull/37