### PR TITLE
ZCS-14748:Fix license-daemon.cnf is missing error in ZCS multi node setup

### DIFF
--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -28,11 +28,6 @@ LICENSE_DAEMON_SERVICE="/opt/zimbra/license/lib/app.jar"
 LICENSE_DAEMON_SERVICE_PORT="8081"
 licenseDaemonServicepid=""
 
-if [ ! -f ${CONFIG_FILE} ]; then
-      echo "Error: ${CONFIG_FILE} is missing."
-      exit 1
-fi
-
 checkLicenseDaemonServiceRunning()
 {
 	licenseDaemonServicepid=`ps -aef | grep ${LICENSE_DAEMON_SERVICE} | grep -v grep |awk '{print $2}'`
@@ -50,6 +45,11 @@ startLicenseDaemonService()
 	echo -n "Starting license daemon service..."
 	if [ $licenseDaemonServiceRunning = 1 ]; then
 		echo "license daemon service is already running."
+		return
+	fi
+	if [ ! -f ${CONFIG_FILE} ]; then
+		echo "Error: ${CONFIG_FILE} is missing."
+		err=1
 		return
 	fi
 	source $CONFIG_FILE


### PR DESCRIPTION
**Issue :** Error: /opt/zimbra/license/config/license-daemon.cnf is missing in ZCS multi node setup

```
$ zmcontrol restart
Host *******
	Stopping vmware-ha...Done.
	Stopping zmconfigd...Done.
	Stopping license-daemon...Failed.
Error: /opt/zimbra/license/config/license-daemon.cnf is missing.


	Stopping zimlet webapp...Done.
	Stopping zimbraAdmin webapp...Done.
	Stopping zimbra webapp...Done.
	Stopping service webapp...Done.
	Stopping stats...Done.
	Stopping onlyoffice...Done.
	Stopping spell...Done.
	Stopping snmp...Done.
	Stopping cbpolicyd...Done.
	Stopping archiving...Done.
	Stopping opendkim...Done.
	Stopping amavis...Done.
	Stopping antivirus...Done.
	Stopping antispam...Done.
	Stopping proxy...Done.
	Stopping memcached...Done.
	Stopping mailbox...Done.
	Stopping logger...Done.
	Stopping dnscache...Done.
Host ******
	Starting zmconfigd...Done.
	Starting onlyoffice...Done.
	Starting stats...Done.

$ zmcontrol status 
Host ******
	onlyoffice              Running
	stats                   Running
	zmconfigd               Running

```

2 node setup
1. ldap + mta + proxy + mailbox + license daemon
2. onlyoffice

**Fix :** Move license daemon config file check to the start block