### PR TITLE
ZBUG-3281: Fix the issue "logrotate is failing on rocky/rhel 8".

### DIFF
--- a/src/libexec/zmsyslogsetup
+++ b/src/libexec/zmsyslogsetup
@@ -313,7 +313,7 @@ sub updateSyslog {
     while (<>) {
       if ( $rsyslog == 1 ) {
         s/syslogd\*.pid/rsyslogd.pid/g;
-        if ($platform eq "RHEL7_64") {
+        if ($platform eq "RHEL7_64"  || $platform eq "RHEL8_64" || $platform eq "RHEL9_64") {
       		s/#su zimbra zimbra/su zimbra zimbra/;
       	}
 	if ($platform eq "RHEL8_64") {


### PR DESCRIPTION
Problem: When we run logrotate script(/etc/logrotate.d/zimbra) on rocky 8, it fails with following error. 
`error: /etc/logrotate.d/zimbra:5 unknown user 'USER'`

Fix: Since the script wasn't recognising the user therefore added the RHEL 8 conditional check for switching to zimbra user while execution of script.