### PR TITLE
ZCS-14841 : Update zmdbintegrityreport to add check for mailbox user account consistency check

### DIFF
--- a/src/libexec/zmdbintegrityreport
+++ b/src/libexec/zmdbintegrityreport
@@ -132,15 +132,31 @@ sub checkDbs() {
       }
     }
   }
-  if (scalar @output != 0) {
-    addToReport("Database errors found.\n");
-    addToReport("$cmd --password=XXXXXXXX\n");
-    addToReport("@output");
-    if(!$options{m}) {
-      return 1;
-    }
+  my $mysql_cmd = "/opt/zimbra/common/bin/mysql -S ${mysql_socket} -u root --password=${mysql_root_passwd}";
+  my @mistmatch_records;
+  for my $num (1..100) {
+	  if (system("$mysql_cmd -e 'use mboxgroup$num' 2>/dev/null") == 0) {
+		  my $query = "select id from zimbra.mailbox where group_id=$num and id not in (select distinct(mailbox_id) from mboxgroup$num.mail_item)";
+		  my $query_output = `$mysql_cmd -e "$query"`;
+		  my $num_rows = () = $query_output =~ /\n/g;
+		  if ($num_rows >= 1) {
+			  push @mistmatch_records, "Error: Found mailbox record mismatch with mail_item for DB mboxgroup$num\n";
+			  push @mistmatch_records, "Query: $query\n";
+			  my @mailbox_ids = split /\n/, $query_output;
+			  push @mistmatch_records, map { "  $_\n" } @mailbox_ids;
+		  }
+	  }
+  }
+  if (scalar @output || scalar @mistmatch_records) {
+	  addToReport("Database errors found.\n");
+	  addToReport("$cmd --password=XXXXXXXX\n");
+	  addToReport("@output");
+	  addToReport("@mistmatch_records");
+	  if (!$options{m}) {
+		  return 1;
+	  }
   } else {
-    addToReport("No errors found\n") if $verbose;
+	  addToReport("No errors found\n") if $verbose;
   }
   unless (close(CMD)) {
     addToReport("command failed $!\n");;


### PR DESCRIPTION
During upgrade to ZCS-10 there are DB errors reported in some setups where the user accounts are not consistent within database for tables mailbox & mail_item. These result into DB error for foreign key constraints.

```
Fri Nov 17 20:28:32 2023 Fri Nov 17 20:28:32 2023: Updating DB schema version from 115 to 116.
Fri Nov 17 20:28:34 2023 Running /opt/zimbra/libexec/scripts/migrate20220729-FilesShareWithMeFolder.pl
Fri Nov 17 20:28:39 2023 Fri Nov 17 20:28:39 2023: Verified schema version 116.
Fri Nov 17 20:28:49 2023 .....Fri Nov 17 20:28:49 2023: DB: INSERT INTO mboxgroup5.mail_item (
Fri Nov 17 20:28:49 2023 mailbox_id, id, type, parent_id, folder_id, index_id, imap_id,
Fri Nov 17 20:28:49 2023 date, size, blob_digest,
Fri Nov 17 20:28:49 2023 unread, flags, tags, sender,
Fri Nov 17 20:28:49 2023 subject, name, metadata,
Fri Nov 17 20:28:49 2023 mod_metadata, change_date, mod_content
Fri Nov 17 20:28:49 2023 )
Fri Nov 17 20:28:49 2023 SELECT
Fri Nov 17 20:28:49 2023 id, 20, 1, 1, 1, null, null,
Fri Nov 17 20:28:49 2023 1700281719, 0, null,
Fri Nov 17 20:28:49 2023 0, 0, 0, null,
Fri Nov 17 20:28:49 2023 'Files shared with me', 'Files shared with me', 'd1:ai1e3:das5:false4:mseqi1e4:unxti21e1:vi10e2:vti8ee',
Fri Nov 17 20:28:49 2023 change_checkpoint, 1700281719, change_checkpoint
Fri Nov 17 20:28:49 2023 FROM mailbox
Fri Nov 17 20:28:49 2023 WHERE group_id = 5
Fri Nov 17 20:28:49 2023 ON DUPLICATE KEY UPDATE name = 'Files shared with me';: Cannot add or update a child row: a foreign key constraint fails (`mboxgroup5`.`mail_item`, CONSTRAINT `fk_mail_item_folder_id` FOREIGN KEY (`mailbox_id`, `folder_id`) REFERENCES `mail_item` (`mailbox_id`, `id`))
Fri Nov 17 20:28:49 2023
Fri Nov 17 20:28:49 2023 Died at /opt/zimbra/libexec/scripts/Migrate.pm line 372, <OUTPUT> line 760.
Fri Nov 17 20:28:53 2023 Script failed with code 256: - exiting
Fri Nov 17 20:28:53 2023 UPGRADE FAILED - exiting.
```