### PR TITLE
ZBUG-3281: Fix the issue "logrotate is failing on rocky/rhel 8"

### DIFF
--- a/conf/zmlogrotate
+++ b/conf/zmlogrotate
@@ -3,6 +3,7 @@
     missingok
     notifempty
     create 0644 USER GROUP
+    #su root adm
     postrotate
       kill -HUP `cat /var/run/syslog*.pid 2> /dev/null` 2> /dev/null || true
       su - zimbra -c "/opt/zimbra/bin/zmconfigdctl restart" > /dev/null 2>&1 || true
@@ -15,6 +16,7 @@
     missingok
     notifempty
     create 0644 USER GROUP
+    #su root adm
     postrotate
       kill -HUP `cat /var/run/syslog*.pid 2> /dev/null` 2> /dev/null || true
       su - zimbra -c "/opt/zimbra/bin/zmconfigdctl restart" > /dev/null 2>&1 || true

--- a/src/libexec/zmsyslogsetup
+++ b/src/libexec/zmsyslogsetup
@@ -426,6 +426,7 @@ sub updateRsyslogd {
         s/GROUP/zimbra/;
       }
       if ($platform eq "UBUNTU14_64" || $platform eq "UBUNTU16_64" || $platform eq "UBUNTU18_64" || $platform eq "UBUNTU20_64") {
+      	s/#su root adm/su root adm/;
       	s/#su zimbra zimbra/su zimbra zimbra/;
       }
       print;


### PR DESCRIPTION
Issue: Logrotate was failing on Ubuntu 18 and 20 due to insufficient permission error.
Fix: Given access rights to the files in the form of comment which shall be converted to statements in case of Ubuntu 18 and 20.
Result: Logrotate was able to manage logs in `/var/log/zimbra.log` and `/var/log/zimbra-stats.log` Files

