### PR TITLE
ZCS-15117 : modified version_re variable to work with new nomenclatur…

### DIFF
--- a/src/libexec/zmupdatezco
+++ b/src/libexec/zmupdatezco
@@ -36,7 +36,7 @@ fi
 client_file_basename=`basename $client_file`
 
 # sed RE
-version_re='[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.*\(_BETA[^_]*_\)*\(_GA_\)*[0-9][0-9]*'
+version_re='[0-9]*\.*[0-9]*\.*[0-9]*\.*\(_BETA[^_]*_\)*\(_GA_\)*[0-9][0-9]*'
 client_file_appglob=`echo $client_file_basename | sed -e "s/$version_re/*/"`
 
 if [ ! -r ${client_file} ]; then


### PR DESCRIPTION
Problem:
 if we run the above command   su - zimbra -c "/opt/zimbra/libexec/zmupdatezco /tmp/ZimbraConnectorOLK_9.0.0.1941_x64.msi" 

1.Above commands Copies the new binaries to the Location (/opt/zimbra/jetty_base/webapps/zimbra/downloads)
2. But it didn’t remove any existing similar File. Instead it throws an error.

Analysis - the version_re will not work with new Nomenclature as it need compulsory 9.0.0 part but in new Nomenclature we don't have ZCO version number.

Solution - Modified version_re to work with old and new Nomenclature.
