### PR TITLE
ZCS-15521: Logs of License Daemon Service (LDS) are lost after servic…

### DIFF
--- a/src/bin/zmlicensectl
+++ b/src/bin/zmlicensectl
@@ -23,7 +23,6 @@ fi
 CONFIG_FILE=/opt/zimbra/license/config/license-daemon.cnf
 ZMJAVA="/opt/zimbra/common/lib/jvm/java/bin/java"
 LD_LIBRARY_PATH="/opt/zimbra/license/lib"
-LICENSE_DAEMON_SERVICE_OUTPUT="/opt/zimbra/log/license-daemon-service.log"
 LICENSE_DAEMON_SERVICE="/opt/zimbra/license/lib/app.jar"
 LICENSE_DAEMON_SERVICE_PORT="8081"
 licenseDaemonServicepid=""
@@ -66,9 +65,9 @@ startLicenseDaemonService()
 		zimbra_license_daemon_offline_mode=false
 	fi
 	if [ -f ${LD_LIBRARY_PATH}/libShafer-prod-linux64.so ]; then
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=prod --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=prod --server.port=$LICENSE_DAEMON_SERVICE_PORT > /dev/null 2>&1 &
 	else
-		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > $LICENSE_DAEMON_SERVICE_OUTPUT 2>&1 &
+		export LD_LIBRARY_PATH; nohup ${ZMJAVA} -Dlicense-daemon.log.level=${zimbra_license_daemon_log_level} -Dlicense-daemon.offline.mode=${zimbra_license_daemon_offline_mode} -jar $LICENSE_DAEMON_SERVICE --spring.profiles.active=dev --server.port=$LICENSE_DAEMON_SERVICE_PORT > /dev/null 2>&1 &
 	fi
 	sleep 5
 	checkLicenseDaemonServiceRunning
@@ -319,6 +318,7 @@ case "$1" in
 			  		exit 0
 			  	fi
 			  	;;
+			 
 			"getLogLevel")
 			  # Ensure exact match for "getLogLevel"
 			  if [ "$#" -ne 2 ]; then


### PR DESCRIPTION
Ticket - [ZCS-15521](https://synacor.atlassian.net/browse/ZCS-15521)

- Adding logback-spring.xml configurations to LDS
- Log file will be generated with below pattern 
<img width="640" alt="Screenshot 2024-08-01 at 12 19 56 PM" src="https://github.com/user-attachments/assets/ebf0e1a8-fa49-4727-83a3-a097353def99">

- Now log files are going to be saved at this location:  _/opt/zimbra/log/zm-license-daemon.log_  <-under this file. So we can do the log search by using this command _tail -f log/zm-license-daemon.log_  for current log / today's log file.

Link to LDS PR: https://github.com/Zimbra/zm-license-daemon-service/pull/75

[ZCS-15521]: https://synacor.atlassian.net/browse/ZCS-15521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ