### PR TITLE
ZBUG-4876:adding Ubuntu22 platform condition for zmfixperms

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -36,7 +36,7 @@ fi
 postfix_owner=postfix
 postfix_suid_group=postdrop
 
-if [ "X$PLAT" = "XUBUNTU10_64" -o "X$PLAT" = "XUBUNTU12_64" -o "X$PLAT" = "XUBUNTU14_64" -o X$PLAT = "XUBUNTU16_64" -o X$PLAT = "XUBUNTU18_64" -o X$PLAT = "XUBUNTU20_64" ]; then
+if [ "X$PLAT" = "XUBUNTU10_64" -o "X$PLAT" = "XUBUNTU12_64" -o "X$PLAT" = "XUBUNTU14_64" -o X$PLAT = "XUBUNTU16_64" -o X$PLAT = "XUBUNTU18_64" -o X$PLAT = "XUBUNTU20_64" -o X$PLAT = "XUBUNTU22_64" ]; then
   syslog_user=syslog
   syslog_group=adm
 else


### PR DESCRIPTION
As part of ZBUG-4876 Fix , added condition for Ubuntu22 OS in zmfixperms which sets correct group and user permission for `zimbra.log`, As below->
**root@platform-dev-testmachine:/opt/zimbra# ls -la /var/log/zimbra.log
-rw-r--r-- 1 syslog adm 1508474 Jul 21 11:45 /var/log/zimbra.log**
