### PR TITLE
ZBUG-4177 Exclude devices prevent disk warning

### DIFF
--- a/src/libexec/zmstat-df
+++ b/src/libexec/zmstat-df
@@ -35,7 +35,7 @@ chomp $hostname;
 my $platform = qx(/opt/zimbra/libexec/get_plat_tag.sh);
 chomp $platform;
 
-my $DF = '/bin/df -k';
+my $DF = '/bin/df -k -x squashfs';
 my $HEADING = 'timestamp, path, disk, disk_use, disk_space, disk_pct_used';
 
 my @DF_EXCLUDES = split(/:/, getLocalConfig("zmstat_df_excludes") || "");


### PR DESCRIPTION
Signed-off-by: Afan Ottenheimer <noreply@ottenheimer.com>


I noticed an earlier attempt at https://github.com/Zimbra/zm-core-utils/pull/164 that wasn't signed and added some exclusions I didn't see in my own testing. Here's a new pull without those extra exclusions that fixes https://wiki.zimbra.com/wiki/Disable_Disk_Space_Monitoring_for_Loop_Devices 